### PR TITLE
fix: edge download url should not be http

### DIFF
--- a/dist/edge/install.sh
+++ b/dist/edge/install.sh
@@ -175,13 +175,9 @@ if [[ "$HTTP_PORT" == "$SERVER_HTTP_ADDR" ]]; then
     HTTP_PORT="443"
 fi
 
-# 根据端口选择协议
-if [[ "$HTTP_PORT" == "443" ]]; then
-    PACKAGE_URL="https://${SERVER_HTTP_ADDR}/packages/edge/${PACKAGE_NAME}"
-else
-    PACKAGE_URL="http://${SERVER_HTTP_ADDR}/packages/edge/${PACKAGE_NAME}"
-fi
-echo -e "${YELLOW}HTTP download address: ${SERVER_HTTP_ADDR}${NC}"
+PACKAGE_URL="https://${SERVER_HTTP_ADDR}/packages/edge/${PACKAGE_NAME}"
+
+echo -e "${YELLOW}HTTPS download address: ${SERVER_HTTP_ADDR}${NC}"
 echo -e "${YELLOW}Edge connection address: ${SERVER_EDGE_ADDR}${NC}"
 echo -e "${YELLOW}Package URL: ${PACKAGE_URL}${NC}"
 


### PR DESCRIPTION
The liaison server is forced to use HTTPS instead of HTTP, even if server port is not 443. So HTTP perfix shoud not be used in edge download url.
<img width="1541" height="493" alt="image" src="https://github.com/user-attachments/assets/11ff67dc-e90b-4169-bc8a-b4b3b12cd749" />

