### PR TITLE
ci(desktop-client): canonical asset names for releases

### DIFF
--- a/.github/workflows/desktop-client-macos.yml
+++ b/.github/workflows/desktop-client-macos.yml
@@ -101,22 +101,34 @@ jobs:
         working-directory: desktop-client
         run: pnpm tauri build --target universal-apple-darwin
 
-      - name: Stamp .dmg filename with date + commit
-        # Tauri's default name (Liaison_0.1.0_universal.dmg) is stable so
-        # the rolling URL doesn't change, but a stale cached download is
-        # indistinguishable from a fresh one. Add a second .dmg whose
-        # filename embeds the build date + short sha, so a tester can
-        # tell at a glance which build they're holding.
+      - name: Rename + stamp .dmg
+        # Tauri's default name (Liaison_0.1.0_universal.dmg) was fine for
+        # internal testing, but liaison.cloud advertises the canonical
+        # form `Liaison-Desktop-vX.Y.Z-macOS-universal.dmg`. Rename the
+        # build output to that form so the GH release filename matches
+        # the URL on the site, and add a second copy with the build
+        # date + short sha so testers can tell stamped builds apart.
         shell: bash
         run: |
           sha="${GITHUB_SHA:0:7}"
           date="$(date -u +%Y%m%d-%H%M)"
-          stamp="_${date}_${sha}"
+          stamp="${date}_${sha}"
           bd="desktop-client/src-tauri/target/universal-apple-darwin/release/bundle/dmg"
-          for f in "$bd"/*.dmg; do
-            base="${f%.dmg}"
-            cp "$f" "${base}${stamp}.dmg"
-            echo "  stamped: ${base}${stamp}.dmg"
+          # tag-triggered runs use the tag (e.g. "desktop-v0.1.0"); for
+          # branch builds fall back to the branch name so the file is
+          # still self-describing.
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            ver="${GITHUB_REF_NAME#desktop-}"
+          else
+            ver="dev-${GITHUB_REF_NAME//\//-}"
+          fi
+          for f in "$bd"/Liaison_*.dmg; do
+            [ -e "$f" ] || continue
+            canonical="$bd/Liaison-Desktop-${ver}-macOS-universal.dmg"
+            cp "$f" "$canonical"
+            cp "$f" "$bd/Liaison-Desktop-${ver}-macOS-universal_${stamp}.dmg"
+            rm "$f"
+            echo "  canonical: $canonical"
           done
 
       - name: Locate produced bundle

--- a/.github/workflows/desktop-client-windows.yml
+++ b/.github/workflows/desktop-client-windows.yml
@@ -75,29 +75,39 @@ jobs:
         working-directory: desktop-client
         run: pnpm tauri build
 
-      - name: Stamp installer filenames with date + commit
-        # The Tauri-default name (Liaison_0.1.0_x64_en-US.msi) is stable so
-        # the rolling-release URL doesn't change, but a fresh download is
-        # indistinguishable from a cached one. Copy the bundles to a
-        # second filename that includes the build date + short sha so a
-        # tester can confirm which build they're looking at by glancing
-        # at the file in their Downloads folder. Both names ship to the
-        # release.
+      - name: Rename + stamp installer filenames
+        # Tauri's default name (Liaison_0.1.0_x64_en-US.msi) was fine
+        # for internal testing, but liaison.cloud advertises the
+        # canonical form `Liaison-Desktop-vX.Y.Z-Windows-x64.msi`.
+        # Rename to that form so the GH release filename matches the
+        # URL on the site, and emit a second copy with the build date
+        # + short sha so testers can tell stamped builds apart.
         shell: pwsh
         run: |
           $sha   = "${{ github.sha }}".Substring(0, 7)
           $date  = Get-Date -Format "yyyyMMdd-HHmm"
-          $stamp = "_${date}_${sha}"
+          $stamp = "${date}_${sha}"
           $bundleDir = "desktop-client/src-tauri/target/release/bundle"
-          foreach ($msi in Get-ChildItem -Path "$bundleDir/msi" -Filter *.msi -ErrorAction SilentlyContinue) {
-            $stamped = $msi.FullName -replace '\.msi$', "$stamp.msi"
-            Copy-Item $msi.FullName $stamped
-            Write-Host "  stamped: $stamped"
+          if ("${env:GITHUB_REF}" -like "refs/tags/*") {
+            $ver = "${env:GITHUB_REF_NAME}" -replace "^desktop-", ""
+          } else {
+            $ver = "dev-" + (("${env:GITHUB_REF_NAME}") -replace "/", "-")
           }
-          foreach ($exe in Get-ChildItem -Path "$bundleDir/nsis" -Filter *-setup.exe -ErrorAction SilentlyContinue) {
-            $stamped = $exe.FullName -replace '-setup\.exe$', "${stamp}-setup.exe"
+          foreach ($msi in Get-ChildItem -Path "$bundleDir/msi" -Filter "Liaison_*.msi" -ErrorAction SilentlyContinue) {
+            $canonical = Join-Path $msi.DirectoryName "Liaison-Desktop-${ver}-Windows-x64.msi"
+            $stamped   = Join-Path $msi.DirectoryName "Liaison-Desktop-${ver}-Windows-x64_${stamp}.msi"
+            Copy-Item $msi.FullName $canonical
+            Copy-Item $msi.FullName $stamped
+            Remove-Item $msi.FullName
+            Write-Host "  canonical: $canonical"
+          }
+          foreach ($exe in Get-ChildItem -Path "$bundleDir/nsis" -Filter "Liaison_*-setup.exe" -ErrorAction SilentlyContinue) {
+            $canonical = Join-Path $exe.DirectoryName "Liaison-Desktop-${ver}-Windows-x64-setup.exe"
+            $stamped   = Join-Path $exe.DirectoryName "Liaison-Desktop-${ver}-Windows-x64-setup_${stamp}.exe"
+            Copy-Item $exe.FullName $canonical
             Copy-Item $exe.FullName $stamped
-            Write-Host "  stamped: $stamped"
+            Remove-Item $exe.FullName
+            Write-Host "  canonical: $canonical"
           }
 
       - name: Locate produced bundles


### PR DESCRIPTION
## Summary
- Renames Tauri's default bundle outputs (e.g. `Liaison_0.1.0_universal.dmg`) to a canonical `Liaison-Desktop-vX.Y.Z-<os>-<arch>.<ext>` shape in CI before the GitHub release step.
- Tag runs use the tag (e.g. `desktop-v0.1.0` -> `v0.1.0`); branch runs use `dev-<branch>` so the file stays self-describing.
- Date + sha stamped copies still ship alongside for differentiating two builds of the same tag.

## Why
liaison.cloud now self-hosts the install packages at `/downloads/...` (see liaisonio/liaison-cloud commit 0c5fb18) under the canonical names. The next desktop-vX.Y.Z tag should produce GitHub release assets that match the URLs advertised on the site.

## Test plan
- [ ] Push a `desktop-v0.1.1` (or rc) tag and confirm the CI emits `Liaison-Desktop-v0.1.1-macOS-universal.dmg`, `Liaison-Desktop-v0.1.1-Windows-x64.msi`, `Liaison-Desktop-v0.1.1-Windows-x64-setup.exe`
- [ ] Confirm a non-tag push names files `Liaison-Desktop-dev-<branch>-...`
- [ ] Confirm `Liaison_*.dmg` / `Liaison_*.msi` / `Liaison_*-setup.exe` no longer appear in the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
