### PR TITLE
fix: enforce lifecycle consistency across assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ certs/*.crt
 /deploy/docker/data/
 /deploy/docker/certs/
 /deploy/docker/logs/
+
+# Local runtime state
+/local-run/

--- a/api/v1/liaison.pb.go
+++ b/api/v1/liaison.pb.go
@@ -2201,18 +2201,20 @@ func (x *DeleteApplicationResponse) GetMessage() string {
 
 // 代理
 type Proxy struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Port          int32                  `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
-	Status        string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
-	Application   *Application           `protobuf:"bytes,5,opt,name=application,proto3" json:"application,omitempty"`
-	Description   string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
-	CreatedAt     string                 `protobuf:"bytes,7,opt,name=created_at,proto3" json:"created_at,omitempty"`
-	UpdatedAt     string                 `protobuf:"bytes,8,opt,name=updated_at,proto3" json:"updated_at,omitempty"`
-	AccessUrl     string                 `protobuf:"bytes,9,opt,name=access_url,proto3" json:"access_url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Id                     uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name                   string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Port                   int32                  `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
+	Status                 string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	Application            *Application           `protobuf:"bytes,5,opt,name=application,proto3" json:"application,omitempty"`
+	Description            string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
+	CreatedAt              string                 `protobuf:"bytes,7,opt,name=created_at,proto3" json:"created_at,omitempty"`
+	UpdatedAt              string                 `protobuf:"bytes,8,opt,name=updated_at,proto3" json:"updated_at,omitempty"`
+	AccessUrl              string                 `protobuf:"bytes,9,opt,name=access_url,proto3" json:"access_url,omitempty"`
+	EffectiveStatus        string                 `protobuf:"bytes,10,opt,name=effective_status,proto3" json:"effective_status,omitempty"`
+	EffectiveStatusMessage string                 `protobuf:"bytes,11,opt,name=effective_status_message,proto3" json:"effective_status_message,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Proxy) Reset() {
@@ -2304,6 +2306,20 @@ func (x *Proxy) GetUpdatedAt() string {
 func (x *Proxy) GetAccessUrl() string {
 	if x != nil {
 		return x.AccessUrl
+	}
+	return ""
+}
+
+func (x *Proxy) GetEffectiveStatus() string {
+	if x != nil {
+		return x.EffectiveStatus
+	}
+	return ""
+}
+
+func (x *Proxy) GetEffectiveStatusMessage() string {
+	if x != nil {
+		return x.EffectiveStatusMessage
 	}
 	return ""
 }
@@ -4238,7 +4254,7 @@ const file_liaison_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\"I\n" +
 	"\x19DeleteApplicationResponse\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\x05R\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\x89\x02\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xf1\x02\n" +
 	"\x05Proxy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -4254,7 +4270,10 @@ const file_liaison_proto_rawDesc = "" +
 	"updated_at\x12\x1e\n" +
 	"\n" +
 	"access_url\x18\t \x01(\tR\n" +
-	"access_url\"A\n" +
+	"access_url\x12*\n" +
+	"\x10effective_status\x18\n" +
+	" \x01(\tR\x10effective_status\x12:\n" +
+	"\x18effective_status_message\x18\v \x01(\tR\x18effective_status_message\"A\n" +
 	"\aProxies\x12\x14\n" +
 	"\x05total\x18\x01 \x01(\x05R\x05total\x12 \n" +
 	"\aproxies\x18\x02 \x03(\v2\x06.ProxyR\aproxies\"Z\n" +

--- a/api/v1/liaison.proto
+++ b/api/v1/liaison.proto
@@ -250,6 +250,8 @@ message Proxy {
     string created_at = 7 [json_name = "created_at"];
     string updated_at = 8 [json_name = "updated_at"];
     string access_url = 9 [json_name = "access_url"];
+    string effective_status = 10 [json_name = "effective_status"];
+    string effective_status_message = 11 [json_name = "effective_status_message"];
 }
 
 message Proxies {

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -10,6 +10,10 @@ MANAGER_PORT=443
 # Bound on the host (not via docker-proxy).
 FRONTIER_PORT=30012
 
+# Frontier controlplane port — liaison uses this local loopback endpoint to
+# actively disconnect deleted connectors. Keep it closed to the public network.
+FRONTIER_CONTROLPLANE_PORT=30010
+
 # First-run admin account email. Password is auto-generated on first start
 # and printed once to `docker compose logs liaison` — save it.
 LIAISON_ADMIN_EMAIL=default@liaison.com

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -82,6 +82,7 @@ make package-docker
 |:---|:---|:---|
 | `MANAGER_PORT`(默认 443) | Web 控制台 HTTPS | 是 |
 | `FRONTIER_PORT`(默认 30012) | 连接器接入 | 是 |
+| `FRONTIER_CONTROLPLANE_PORT`(默认 30010) | liaison 主动断开连接器连接 | 否(loopback) |
 | 127.0.0.1:30011 | liaison ↔ frontier 本地通信 | 否(loopback) |
 
 Edge 连接器在 Web 里创建时会自动把 `LIAISON_PUBLIC_HOST:FRONTIER_PORT` 写进安装命令。改了 `FRONTIER_PORT` 之后,已发出去的 edge 安装命令也会指向新端口,老的 edge 需要重新下发。

--- a/deploy/docker/conf/frontier.yaml.template
+++ b/deploy/docker/conf/frontier.yaml.template
@@ -2,6 +2,11 @@ daemon:
   pprof:
     addr: 127.0.0.1:6061
     enable: true
+controlplane:
+  enable: true
+  listen:
+    network: tcp
+    addr: 127.0.0.1:${FRONTIER_CONTROLPLANE_PORT}
 edgebound:
   listen:
     network: tcp

--- a/deploy/docker/conf/liaison.yaml.template
+++ b/deploy/docker/conf/liaison.yaml.template
@@ -18,6 +18,7 @@ manager:
   server_url: ${SERVER_URL}
   jwt_secret: ${JWT_SECRET}
 frontier:
+  controlplane_url: http://127.0.0.1:${FRONTIER_CONTROLPLANE_PORT}
   dial:
     addrs:
       - 127.0.0.1:30011

--- a/deploy/docker/docker-compose.release.yaml
+++ b/deploy/docker/docker-compose.release.yaml
@@ -6,6 +6,7 @@ services:
     network_mode: host
     environment:
       FRONTIER_PORT: ${FRONTIER_PORT:-30012}
+      FRONTIER_CONTROLPLANE_PORT: ${FRONTIER_CONTROLPLANE_PORT:-30010}
     volumes:
       - ./certs:/opt/liaison/certs
 
@@ -22,6 +23,7 @@ services:
       LIAISON_PUBLIC_HOST: ${LIAISON_PUBLIC_HOST:-localhost}
       MANAGER_PORT: ${MANAGER_PORT:-443}
       FRONTIER_PORT: ${FRONTIER_PORT:-30012}
+      FRONTIER_CONTROLPLANE_PORT: ${FRONTIER_CONTROLPLANE_PORT:-30010}
       LIAISON_ADMIN_EMAIL: ${LIAISON_ADMIN_EMAIL:-default@liaison.com}
       # Optional: pass a fixed JWT secret instead of letting first-run generate one.
       # JWT_SECRET: ""

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     network_mode: host
     environment:
       FRONTIER_PORT: ${FRONTIER_PORT:-30012}
+      FRONTIER_CONTROLPLANE_PORT: ${FRONTIER_CONTROLPLANE_PORT:-30010}
     volumes:
       - ./certs:/opt/liaison/certs
 
@@ -28,6 +29,7 @@ services:
       LIAISON_PUBLIC_HOST: ${LIAISON_PUBLIC_HOST:-localhost}
       MANAGER_PORT: ${MANAGER_PORT:-443}
       FRONTIER_PORT: ${FRONTIER_PORT:-30012}
+      FRONTIER_CONTROLPLANE_PORT: ${FRONTIER_CONTROLPLANE_PORT:-30010}
       LIAISON_ADMIN_EMAIL: ${LIAISON_ADMIN_EMAIL:-default@liaison.com}
       # Optional: pass a fixed JWT secret instead of letting first-run generate one.
       # JWT_SECRET: ""

--- a/deploy/docker/entrypoint-frontier.sh
+++ b/deploy/docker/entrypoint-frontier.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # Frontier container entrypoint.
-# Renders the config template (FRONTIER_PORT envsubst'd in), waits for the
-# shared TLS cert to appear (liaison generates it on first run), then execs
-# the frontier binary.
+# Renders the config template, waits for the shared TLS cert to appear
+# (liaison generates it on first run), then execs the frontier binary.
 
 set -eu
 
@@ -10,13 +9,14 @@ CONF_DIR=/opt/liaison/conf
 CERTS_DIR=/opt/liaison/certs
 
 : "${FRONTIER_PORT:=30012}"
+: "${FRONTIER_CONTROLPLANE_PORT:=30010}"
 
 if [ ! -f "$CONF_DIR/frontier.yaml" ]; then
-    export FRONTIER_PORT
+    export FRONTIER_PORT FRONTIER_CONTROLPLANE_PORT
     # shellcheck disable=SC2016
-    envsubst '${FRONTIER_PORT}' \
+    envsubst '${FRONTIER_PORT} ${FRONTIER_CONTROLPLANE_PORT}' \
         < "$CONF_DIR/frontier.yaml.template" > "$CONF_DIR/frontier.yaml"
-    echo "[entrypoint] rendered $CONF_DIR/frontier.yaml (frontier_port=$FRONTIER_PORT)"
+    echo "[entrypoint] rendered $CONF_DIR/frontier.yaml (frontier_port=$FRONTIER_PORT controlplane_port=$FRONTIER_CONTROLPLANE_PORT)"
 fi
 
 for _ in $(seq 1 60); do

--- a/deploy/docker/entrypoint-liaison.sh
+++ b/deploy/docker/entrypoint-liaison.sh
@@ -19,6 +19,7 @@ mkdir -p "$DATA_DIR" "$CERTS_DIR" "$LOG_DIR"
 
 # ---- Render config --------------------------------------------------------
 : "${FRONTIER_PORT:=30012}"
+: "${FRONTIER_CONTROLPLANE_PORT:=30010}"
 : "${LIAISON_PUBLIC_HOST:=localhost}"
 : "${MANAGER_PORT:=443}"
 : "${LIAISON_ADMIN_EMAIL:=default@liaison.com}"
@@ -37,11 +38,11 @@ if [ ! -f "$CONF_DIR/liaison.yaml" ]; then
     if [ -z "${JWT_SECRET:-}" ]; then
         JWT_SECRET=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-32)
     fi
-    export FRONTIER_PORT MANAGER_PORT SERVER_URL JWT_SECRET
+    export FRONTIER_PORT FRONTIER_CONTROLPLANE_PORT MANAGER_PORT SERVER_URL JWT_SECRET
     # shellcheck disable=SC2016
-    envsubst '${FRONTIER_PORT} ${MANAGER_PORT} ${SERVER_URL} ${JWT_SECRET}' \
+    envsubst '${FRONTIER_PORT} ${FRONTIER_CONTROLPLANE_PORT} ${MANAGER_PORT} ${SERVER_URL} ${JWT_SECRET}' \
         < "$CONF_DIR/liaison.yaml.template" > "$CONF_DIR/liaison.yaml"
-    echo "[entrypoint] rendered $CONF_DIR/liaison.yaml (public_host=$LIAISON_PUBLIC_HOST manager_port=$MANAGER_PORT frontier_port=$FRONTIER_PORT)"
+    echo "[entrypoint] rendered $CONF_DIR/liaison.yaml (public_host=$LIAISON_PUBLIC_HOST manager_port=$MANAGER_PORT frontier_port=$FRONTIER_PORT controlplane_port=$FRONTIER_CONTROLPLANE_PORT)"
 fi
 
 # ---- Generate TLS cert ----------------------------------------------------

--- a/dist/liaison/README.md
+++ b/dist/liaison/README.md
@@ -163,6 +163,7 @@ manager:
       enable: false
   db: /opt/liaison/data/liaison.db
 frontier:
+  controlplane_url: http://127.0.0.1:30010
   dial:
     addrs:
       - 127.0.0.1:30011

--- a/dist/liaison/conf/frontier.yaml.template
+++ b/dist/liaison/conf/frontier.yaml.template
@@ -2,6 +2,11 @@ daemon:
   pprof:
     addr: 127.0.0.1:6061
     enable: true
+controlplane:
+  enable: true
+  listen:
+    network: tcp
+    addr: 127.0.0.1:${FRONTIER_CONTROLPLANE_PORT}
 edgebound:
   listen:
     network: tcp

--- a/dist/liaison/conf/liaison.yaml.template
+++ b/dist/liaison/conf/liaison.yaml.template
@@ -18,6 +18,7 @@ manager:
   server_url: ${SERVER_URL}
   jwt_secret: ${JWT_SECRET}  # JWT密钥（必需，至少32字符，安装时自动生成）
 frontier:
+  controlplane_url: http://127.0.0.1:${FRONTIER_CONTROLPLANE_PORT}
   dial:
     addrs:
       - 127.0.0.1:30011

--- a/dist/liaison/install.sh
+++ b/dist/liaison/install.sh
@@ -430,6 +430,7 @@ elif ! [[ "$FRONTIER_PORT" =~ ^[0-9]+$ ]] || [ "$FRONTIER_PORT" -lt 1 ] || [ "$F
     FRONTIER_PORT="$DEFAULT_FRONTIER_PORT"
 fi
 echo -e "${GREEN}${MSG_FRONTIER_PORT_SET} ${BOLD}${CYAN}${FRONTIER_PORT}${NC}${GREEN}${NC}"
+FRONTIER_CONTROLPLANE_PORT="${FRONTIER_CONTROLPLANE_PORT:-30010}"
 
 # Get public IP address or domain
 echo ""
@@ -482,11 +483,12 @@ echo -e "${YELLOW}${MSG_RENDERING_CONFIG}${NC}"
 if [[ -d "$SCRIPT_DIR/conf" ]]; then
     # Render liaison.yaml from template
     if [[ -f "$SCRIPT_DIR/conf/liaison.yaml.template" ]]; then
-        # Replace ${PUBLIC_ADDR}, ${JWT_SECRET}, ${MANAGER_PORT}, ${FRONTIER_PORT}, and ${SERVER_URL} in the template
+        # Replace ${PUBLIC_ADDR}, ${JWT_SECRET}, ${MANAGER_PORT}, ${FRONTIER_PORT}, ${FRONTIER_CONTROLPLANE_PORT}, and ${SERVER_URL} in the template
         sed -e "s|\${PUBLIC_ADDR}|${PUBLIC_ADDR}|g" \
             -e "s|\${JWT_SECRET}|${JWT_SECRET}|g" \
             -e "s|\${MANAGER_PORT}|${MANAGER_PORT}|g" \
             -e "s|\${FRONTIER_PORT}|${FRONTIER_PORT}|g" \
+            -e "s|\${FRONTIER_CONTROLPLANE_PORT}|${FRONTIER_CONTROLPLANE_PORT}|g" \
             -e "s|\${SERVER_URL}|${SERVER_URL}|g" \
             "$SCRIPT_DIR/conf/liaison.yaml.template" > "$CONFIG_DIR/liaison.yaml"
         chown "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR/liaison.yaml"
@@ -497,9 +499,10 @@ if [[ -d "$SCRIPT_DIR/conf" ]]; then
     
     # Render frontier.yaml from template
     if [[ -f "$SCRIPT_DIR/conf/frontier.yaml.template" ]]; then
-        # Replace ${PUBLIC_ADDR} and ${FRONTIER_PORT} if they exist in the template
+        # Replace ${PUBLIC_ADDR}, ${FRONTIER_PORT}, and ${FRONTIER_CONTROLPLANE_PORT} if they exist in the template
         sed -e "s|\${PUBLIC_ADDR}|${PUBLIC_ADDR}|g" \
             -e "s|\${FRONTIER_PORT}|${FRONTIER_PORT}|g" \
+            -e "s|\${FRONTIER_CONTROLPLANE_PORT}|${FRONTIER_CONTROLPLANE_PORT}|g" \
             "$SCRIPT_DIR/conf/frontier.yaml.template" > "$CONFIG_DIR/frontier.yaml"
         chown "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR/frontier.yaml"
         chmod 644 "$CONFIG_DIR/frontier.yaml"

--- a/pkg/entry/entry.go
+++ b/pkg/entry/entry.go
@@ -2,11 +2,7 @@ package entry
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
-	"github.com/jumboframes/armorigo/log"
-	v1 "github.com/liaisonio/liaison/api/v1"
 	"github.com/liaisonio/liaison/pkg/entry/firewall"
 	"github.com/liaisonio/liaison/pkg/entry/frontierbound"
 	"github.com/liaisonio/liaison/pkg/entry/http"
@@ -70,8 +66,9 @@ func NewEntry(conf *config.Configuration, manager controlplane.ControlPlane, tra
 		manager:         manager,
 	}
 
-	err = entry.pullProxyConfigs()
-	if err != nil {
+	manager.ReconcileLifecycleState()
+
+	if err := manager.RestoreProxyListeners(); err != nil {
 		return nil, err
 	}
 
@@ -114,52 +111,6 @@ func (u *unifiedProxyManager) DeleteProxy(ctx context.Context, id int) error {
 	if tcpErr != nil {
 		return tcpErr
 	}
-	return nil
-}
-
-// pullProxyConfigs 定期从manager同步Proxy配置
-func (e *Entry) pullProxyConfigs() error {
-	rsp, err := e.manager.ListProxies(context.Background(), &v1.ListProxiesRequest{
-		Page:     -1,
-		PageSize: -1,
-	})
-	if err != nil {
-		log.Errorf("failed to list proxies: %s", err)
-		return err
-	}
-	if rsp.Code != 200 {
-		log.Errorf("failed to list proxies: %s", rsp.Message)
-		return errors.New(rsp.Message)
-	}
-	log.Infof("list proxies: %s", rsp.Data.GetProxies())
-
-	for _, proxy := range rsp.Data.GetProxies() {
-		application := proxy.Application
-		if application == nil {
-			log.Warnf("proxy %d (name: %s) has no associated application, skipping", proxy.Id, proxy.Name)
-			continue
-		}
-		dst := fmt.Sprintf("%s:%d", application.Ip, application.Port)
-		
-		// 判断是否是 HTTP 应用，如果是则默认使用 HTTPS
-		useHTTPS := false
-		if application.ApplicationType == "http" {
-			useHTTPS = true
-		}
-		
-		// 使用统一的 ProxyManager
-		e.proxyManager.CreateProxy(context.Background(), &proto.Proxy{
-			ID:              int(proxy.Id),
-			Name:            proxy.Name,
-			ProxyPort:       int(proxy.Port),
-			EdgeID:          application.EdgeId,
-			ApplicationID:   uint(application.Id),
-			Dst:             dst,
-			ApplicationType: application.ApplicationType,
-			UseHTTPS:        useHTTPS,
-		})
-	}
-
 	return nil
 }
 

--- a/pkg/liaison/config/config.go
+++ b/pkg/liaison/config/config.go
@@ -45,11 +45,12 @@ type Manager struct {
 	PackagesDir      string        `yaml:"packages_dir,omitempty" json:"packages_dir"`             // 安装包目录，默认 /opt/liaison/packages
 	WebDir           string        `yaml:"web_dir,omitempty" json:"web_dir"`                       // 前端文件目录，如果为空则不提供前端服务
 	FrontierEdgePort int           `yaml:"frontier_edge_port,omitempty" json:"frontier_edge_port"` // Edge 和 Frontier 之间的通信端口
-	JWTSecret        string        `yaml:"jwt_secret,omitempty" json:"jwt_secret"`                // JWT 密钥（必需，至少32字符）
+	JWTSecret        string        `yaml:"jwt_secret,omitempty" json:"jwt_secret"`                 // JWT 密钥（必需，至少32字符）
 }
 
 type Frontier struct {
-	Dial config.Dial `yaml:"dial,omitempty" json:"dial"`
+	Dial            config.Dial `yaml:"dial,omitempty" json:"dial"`
+	ControlPlaneURL string      `yaml:"controlplane_url,omitempty" json:"controlplane_url"`
 }
 
 type Log struct {

--- a/pkg/liaison/liaison.go
+++ b/pkg/liaison/liaison.go
@@ -47,18 +47,51 @@ func NewLiaison() (*Liaison, error) {
 			return nil, err
 		}
 	}
+	// Bind the public manager listener before registering RPCs with Frontier.
+	// A duplicate manager process must fail here without touching Frontier's
+	// service registry; otherwise its short-lived service connection can remove
+	// RPC routes used by the healthy manager process.
+	webListener, err := web.NewListener(config.Conf)
+	if err != nil {
+		return nil, err
+	}
+	listenerOwned := true
+	defer func() {
+		if listenerOwned {
+			_ = webListener.Close()
+		}
+	}()
+
 	// repo
 	repo, err := repo.NewRepo(config.Conf)
 	if err != nil {
 		return nil, err
 	}
+	repoOwned := true
+	defer func() {
+		if repoOwned {
+			_ = repo.Close()
+		}
+	}()
 	// traffic collector
 	trafficCollector := traffic.NewTrafficCollector(repo)
+	trafficCollectorOwned := true
+	defer func() {
+		if trafficCollectorOwned {
+			trafficCollector.Stop()
+		}
+	}()
 	// frontier bound
 	frontierBound, err := frontierbound.NewFrontierBound(config.Conf, repo, trafficCollector)
 	if err != nil {
 		return nil, err
 	}
+	frontierBoundOwned := true
+	defer func() {
+		if frontierBoundOwned {
+			_ = frontierBound.Close()
+		}
+	}()
 	// service layer
 	controlPlane, err := controlplane.NewControlPlane(config.Conf, repo, frontierBound)
 	if err != nil {
@@ -74,20 +107,38 @@ func NewLiaison() (*Liaison, error) {
 		return nil, fmt.Errorf("failed to set JWT secret: %w", err)
 	}
 	// web layer
-	web, err := web.NewWebServer(config.Conf, controlPlane, iamService)
+	webServer, err := web.NewWebServerWithListener(config.Conf, controlPlane, iamService, webListener)
 	if err != nil {
 		return nil, err
 	}
+	listenerOwned = false
+	webOwned := true
+	defer func() {
+		if webOwned {
+			_ = webServer.Close()
+		}
+	}()
 	// entry layer
 	entry, err := entry.NewEntry(config.Conf, controlPlane, trafficCollector)
 	if err != nil {
 		return nil, err
 	}
+	entryOwned := true
+	defer func() {
+		if entryOwned {
+			_ = entry.Close()
+		}
+	}()
 	// 把持久化的防火墙规则推回数据面 —— entry 此时已经把 proxies 起起来了，
 	// 在这里恢复 CIDR 白名单可以避免重启后的短暂宽松窗口。
 	controlPlane.RestoreFirewallRules()
+	webOwned = false
+	frontierBoundOwned = false
+	entryOwned = false
+	trafficCollectorOwned = false
+	repoOwned = false
 	return &Liaison{
-		web:              web,
+		web:              webServer,
 		frontierBound:    frontierBound,
 		entry:            entry,
 		repo:             repo,

--- a/pkg/liaison/manager/controlplane/application.go
+++ b/pkg/liaison/manager/controlplane/application.go
@@ -113,13 +113,13 @@ func (cp *controlPlane) CreateApplication(_ context.Context, req *v1.CreateAppli
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// 重新获取创建的应用，包含完整的关联数据
 	createdApplication, err := cp.repo.GetApplicationByID(application.ID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &v1.CreateApplicationResponse{
 		Code:    200,
 		Message: "success",
@@ -232,11 +232,14 @@ func (cp *controlPlane) ListApplications(_ context.Context, req *v1.ListApplicat
 	for i, app := range applications {
 		applicationIDs[i] = app.ID
 	}
-	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{
-		ApplicationIDs: applicationIDs,
-	})
-	if err != nil {
-		return nil, err
+	var proxies []*model.Proxy
+	if len(applicationIDs) > 0 {
+		proxies, err = cp.repo.ListProxies(&dao.ListProxiesQuery{
+			ApplicationIDs: applicationIDs,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// 创建设备和Proxy映射，并关联到Application
@@ -308,8 +311,7 @@ func (cp *controlPlane) UpdateApplication(_ context.Context, req *v1.UpdateAppli
 }
 
 func (cp *controlPlane) DeleteApplication(_ context.Context, req *v1.DeleteApplicationRequest) (*v1.DeleteApplicationResponse, error) {
-	err := cp.repo.DeleteApplication(uint(req.Id))
-	if err != nil {
+	if err := cp.deleteApplicationCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
 	return &v1.DeleteApplicationResponse{
@@ -352,21 +354,11 @@ func transformApplication(application *model.Application) *v1.Application {
 
 	// 填充Proxy信息（简化版，不包含Application以避免循环依赖）
 	if application.Proxy != nil {
-		// 将 ProxyStatus 转换为字符串
-		var status string
-		switch application.Proxy.Status {
-		case model.ProxyStatusRunning:
-			status = "running"
-		case model.ProxyStatusStopped:
-			status = "stopped"
-		default:
-			status = "unknown"
-		}
 		appV1.Proxy = &v1.Proxy{
 			Id:          uint64(application.Proxy.ID),
 			Name:        application.Proxy.Name,
 			Port:        int32(application.Proxy.Port),
-			Status:      status,
+			Status:      proxyStatusString(application.Proxy.Status),
 			Description: application.Proxy.Description,
 			CreatedAt:   application.Proxy.CreatedAt.Format(time.DateTime),
 			UpdatedAt:   application.Proxy.UpdatedAt.Format(time.DateTime),

--- a/pkg/liaison/manager/controlplane/controlplane.go
+++ b/pkg/liaison/manager/controlplane/controlplane.go
@@ -49,6 +49,8 @@ type ControlPlane interface {
 	// persisted rules. Call after the entry layer has finished starting
 	// its proxies.
 	RestoreFirewallRules()
+	ReconcileLifecycleState()
+	RestoreProxyListeners() error
 }
 
 func NewControlPlane(conf *config.Configuration, repo repo.Repo, frontierBound frontierbound.FrontierBound) (ControlPlane, error) {

--- a/pkg/liaison/manager/controlplane/device.go
+++ b/pkg/liaison/manager/controlplane/device.go
@@ -85,8 +85,7 @@ func (cp *controlPlane) UpdateDevice(_ context.Context, req *v1.UpdateDeviceRequ
 }
 
 func (cp *controlPlane) DeleteDevice(_ context.Context, req *v1.DeleteDeviceRequest) (*v1.DeleteDeviceResponse, error) {
-	err := cp.repo.DeleteDevice(uint(req.Id))
-	if err != nil {
+	if err := cp.deleteDeviceCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
 	return &v1.DeleteDeviceResponse{

--- a/pkg/liaison/manager/controlplane/edge.go
+++ b/pkg/liaison/manager/controlplane/edge.go
@@ -283,6 +283,7 @@ func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest)
 	if err != nil {
 		return nil, err
 	}
+	oldStatus := edge.Status
 	if req.Name != "" {
 		edge.Name = req.Name
 	}
@@ -290,11 +291,32 @@ func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest)
 		edge.Description = req.Description
 	}
 	if req.Status != 0 {
-		edge.Status = model.EdgeStatus(req.Status)
+		switch model.EdgeStatus(req.Status) {
+		case model.EdgeStatusRunning, model.EdgeStatusStopped:
+			edge.Status = model.EdgeStatus(req.Status)
+		default:
+			return nil, fmt.Errorf("unknown edge status: %d", req.Status)
+		}
+	}
+	statusChanged := oldStatus != edge.Status
+	if statusChanged && edge.Status == model.EdgeStatusStopped {
+		if err := cp.stopEdgeProxies(uint64(edge.ID)); err != nil {
+			return nil, err
+		}
+		if err := cp.failActiveEdgeTasks(uint64(edge.ID), "edge stopped"); err != nil {
+			return nil, err
+		}
 	}
 	err = cp.repo.UpdateEdge(edge)
 	if err != nil {
 		return nil, err
+	}
+	if statusChanged && edge.Status == model.EdgeStatusRunning {
+		if err := cp.startEdgeProxies(uint64(edge.ID)); err != nil {
+			edge.Status = oldStatus
+			_ = cp.repo.UpdateEdge(edge)
+			return nil, err
+		}
 	}
 	// 重新获取更新后的 edge 以返回完整数据
 	updatedEdge, err := cp.repo.GetEdge(req.Id)
@@ -309,8 +331,7 @@ func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest)
 }
 
 func (cp *controlPlane) DeleteEdge(_ context.Context, req *v1.DeleteEdgeRequest) (*v1.DeleteEdgeResponse, error) {
-	err := cp.repo.DeleteEdge(req.Id)
-	if err != nil {
+	if err := cp.deleteEdgeCascade(req.Id, newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
 	return &v1.DeleteEdgeResponse{
@@ -325,6 +346,10 @@ func (cp *controlPlane) CreateEdgeScanApplicationTask(_ context.Context, req *v1
 	if err != nil {
 		log.Errorf("get edge error: %s", err)
 		return nil, err
+	}
+	if edge.Status == model.EdgeStatusStopped {
+		log.Errorf("edge is stopped")
+		return nil, errors.New("edge is stopped")
 	}
 	if edge.Online != model.EdgeOnlineStatusOnline {
 		log.Errorf("edge is not online")

--- a/pkg/liaison/manager/controlplane/lifecycle.go
+++ b/pkg/liaison/manager/controlplane/lifecycle.go
@@ -2,11 +2,23 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"time"
 
 	"github.com/jumboframes/armorigo/log"
+	"github.com/liaisonio/liaison/pkg/liaison/repo/dao"
 	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
 	"github.com/liaisonio/liaison/pkg/proto"
+)
+
+const (
+	proxyEffectiveStatusActive      = "active"
+	proxyEffectiveStatusStopped     = "stopped"
+	proxyEffectiveStatusEdgeStopped = "edge_stopped"
+	proxyEffectiveStatusEdgeOffline = "edge_offline"
+	proxyEffectiveStatusInvalid     = "invalid"
 )
 
 // stopProxyRuntime stops the data-plane listener for proxy and revokes any
@@ -14,9 +26,6 @@ import (
 // already-stopped proxy or when no proxyManager is registered.
 func (cp *controlPlane) stopProxyRuntime(proxy *model.Proxy) error {
 	if proxy == nil || cp.proxyManager == nil {
-		return nil
-	}
-	if proxy.Status != model.ProxyStatusRunning {
 		return nil
 	}
 	if err := cp.proxyManager.DeleteProxy(context.Background(), int(proxy.ID)); err != nil {
@@ -35,7 +44,11 @@ func (cp *controlPlane) startProxyRuntime(proxy *model.Proxy, application *model
 	if proxy == nil || application == nil || cp.proxyManager == nil {
 		return nil
 	}
-	if proxy.Status != model.ProxyStatusRunning {
+	eligible, err := cp.proxyRuntimeEligible(proxy, application)
+	if err != nil {
+		return err
+	}
+	if !eligible {
 		return nil
 	}
 	useHTTPS := application.ApplicationType == model.ApplicationTypeHTTP
@@ -51,6 +64,15 @@ func (cp *controlPlane) startProxyRuntime(proxy *model.Proxy, application *model
 	}
 	if err := cp.proxyManager.CreateProxy(context.Background(), protoproxy); err != nil {
 		return err
+	}
+	oldPort := proxy.Port
+	if proxy.Port == 0 && protoproxy.ProxyPort > 0 {
+		proxy.Port = protoproxy.ProxyPort
+		if err := cp.ensureProxyPortAvailable(proxy.Port, proxy.ID); err != nil {
+			_ = cp.stopProxyRuntime(proxy)
+			proxy.Port = oldPort
+			return err
+		}
 	}
 	cp.reapplyFirewall(proxy.ID, proxy.Port)
 	return nil
@@ -91,9 +113,531 @@ func (cp *controlPlane) RestoreFirewallRules() {
 		return
 	}
 	for _, rule := range rules {
+		proxy, err := cp.repo.GetProxyByID(rule.ProxyID)
+		if err != nil {
+			log.Warnf("firewall: proxy=%d missing, skip restore: %v", rule.ProxyID, err)
+			continue
+		}
+		application, err := cp.repo.GetApplicationByID(proxy.ApplicationID)
+		if err != nil {
+			log.Warnf("firewall: application=%d missing for proxy=%d, skip restore: %v", proxy.ApplicationID, proxy.ID, err)
+			continue
+		}
+		eligible, err := cp.proxyRuntimeEligible(proxy, application)
+		if err != nil || !eligible {
+			cp.firewallManager.Revoke(int(rule.ProxyID))
+			continue
+		}
 		if err := cp.firewallManager.Allow(int(rule.ProxyID), []string(rule.AllowedCIDRs)); err != nil {
 			log.Warnf("firewall: restore proxy=%d failed: %v", rule.ProxyID, err)
 		}
 	}
 	log.Infof("firewall: restored %d rule(s) from DB", len(rules))
+}
+
+// ReconcileLifecycleState repairs persisted lifecycle state before entry starts
+// listeners. It is intentionally conservative: stale runtime is stopped and
+// orphaned proxies are soft-deleted, while traffic/task history is retained.
+func (cp *controlPlane) ReconcileLifecycleState() {
+	if cp.repo == nil {
+		return
+	}
+	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{})
+	if err != nil {
+		log.Warnf("lifecycle: list proxies for reconcile failed: %v", err)
+		return
+	}
+	for _, proxy := range proxies {
+		application, appErr := cp.repo.GetApplicationByID(proxy.ApplicationID)
+		if appErr != nil || application == nil {
+			log.Warnf("lifecycle: deleting orphan proxy %d, application %d missing", proxy.ID, proxy.ApplicationID)
+			if err := cp.stopProxyRuntime(proxy); err != nil {
+				log.Warnf("lifecycle: stop orphan proxy %d failed, keeping record for retry: %v", proxy.ID, err)
+				continue
+			}
+			if err := cp.repo.DeleteFirewallRuleByProxyID(proxy.ID); err != nil {
+				log.Warnf("lifecycle: delete firewall rule for orphan proxy %d failed: %v", proxy.ID, err)
+			}
+			if err := cp.repo.DeleteProxy(proxy.ID); err != nil {
+				log.Warnf("lifecycle: delete orphan proxy %d failed: %v", proxy.ID, err)
+			}
+			continue
+		}
+
+		if proxy.Status == model.ProxyStatusStopped {
+			if err := cp.stopProxyRuntime(proxy); err != nil {
+				log.Warnf("lifecycle: stop disabled proxy %d failed: %v", proxy.ID, err)
+			}
+			continue
+		}
+
+		eligible, eligibleErr := cp.proxyRuntimeEligible(proxy, application)
+		if eligibleErr != nil {
+			log.Warnf("lifecycle: proxy %d invalid, deleting: %v", proxy.ID, eligibleErr)
+			if err := cp.stopProxyRuntime(proxy); err != nil {
+				log.Warnf("lifecycle: stop invalid proxy %d failed, keeping record for retry: %v", proxy.ID, err)
+				continue
+			}
+			if err := cp.repo.DeleteFirewallRuleByProxyID(proxy.ID); err != nil {
+				log.Warnf("lifecycle: delete firewall rule for invalid proxy %d failed: %v", proxy.ID, err)
+			}
+			if err := cp.repo.DeleteProxy(proxy.ID); err != nil {
+				log.Warnf("lifecycle: delete invalid proxy %d failed: %v", proxy.ID, err)
+			}
+			continue
+		}
+		if !eligible {
+			if err := cp.stopProxyRuntime(proxy); err != nil {
+				log.Warnf("lifecycle: stop non-runnable proxy %d failed: %v", proxy.ID, err)
+			}
+		}
+	}
+}
+
+func (cp *controlPlane) RestoreProxyListeners() error {
+	if cp.repo == nil || cp.proxyManager == nil {
+		return nil
+	}
+	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{})
+	if err != nil {
+		return err
+	}
+	started := make([]*model.Proxy, 0, len(proxies))
+	for _, proxy := range proxies {
+		if proxy.Status != model.ProxyStatusRunning {
+			continue
+		}
+		application, err := cp.repo.GetApplicationByID(proxy.ApplicationID)
+		if err != nil {
+			log.Warnf("lifecycle: skip restore proxy %d, application %d missing: %v", proxy.ID, proxy.ApplicationID, err)
+			continue
+		}
+		eligible, err := cp.proxyRuntimeEligible(proxy, application)
+		if err != nil {
+			log.Warnf("lifecycle: skip restore proxy %d, invalid runtime state: %v", proxy.ID, err)
+			continue
+		}
+		if !eligible {
+			continue
+		}
+		proxy.Application = application
+		if err := cp.startAndPersistProxyRuntime(proxy); err != nil {
+			for _, startedProxy := range started {
+				_ = cp.stopProxyRuntime(startedProxy)
+			}
+			return err
+		}
+		started = append(started, proxy)
+	}
+	return nil
+}
+
+func (cp *controlPlane) proxyRuntimeEligible(proxy *model.Proxy, application *model.Application) (bool, error) {
+	if proxy == nil || proxy.Status != model.ProxyStatusRunning {
+		return false, nil
+	}
+	if application == nil {
+		return false, errors.New("proxy application is missing")
+	}
+	if len(application.EdgeIDs) == 0 {
+		return false, errors.New("application has no edge")
+	}
+	edge, err := cp.repo.GetEdge(uint64(application.EdgeIDs[0]))
+	if err != nil {
+		return false, fmt.Errorf("application edge %d is missing: %w", application.EdgeIDs[0], err)
+	}
+	if edge.Status == model.EdgeStatusStopped {
+		return false, nil
+	}
+	if edge.Status != model.EdgeStatusRunning {
+		return false, fmt.Errorf("unknown edge status %d", edge.Status)
+	}
+	return true, nil
+}
+
+func (cp *controlPlane) validateProxyApplication(application *model.Application) (*model.Edge, error) {
+	if application == nil {
+		return nil, errors.New("application is missing")
+	}
+	if len(application.EdgeIDs) == 0 {
+		return nil, errors.New("application has no edge")
+	}
+	edge, err := cp.repo.GetEdge(uint64(application.EdgeIDs[0]))
+	if err != nil {
+		return nil, err
+	}
+	if edge.Status != model.EdgeStatusRunning && edge.Status != model.EdgeStatusStopped {
+		return nil, fmt.Errorf("unknown edge status %d", edge.Status)
+	}
+	return edge, nil
+}
+
+func (cp *controlPlane) proxyEffectiveStatus(proxy *model.Proxy, application *model.Application) (string, string) {
+	if proxy == nil {
+		return proxyEffectiveStatusInvalid, "访问不存在"
+	}
+	if proxy.Status == model.ProxyStatusStopped {
+		return proxyEffectiveStatusStopped, "访问未启用"
+	}
+	if proxy.Status != model.ProxyStatusRunning {
+		return proxyEffectiveStatusInvalid, "访问状态无效"
+	}
+	edge, err := cp.validateProxyApplication(application)
+	if err != nil {
+		return proxyEffectiveStatusInvalid, "关联应用或连接器无效"
+	}
+	if edge.Status == model.EdgeStatusStopped {
+		return proxyEffectiveStatusEdgeStopped, "连接器已禁用"
+	}
+	if edge.Online != model.EdgeOnlineStatusOnline {
+		return proxyEffectiveStatusEdgeOffline, "连接器离线"
+	}
+	return proxyEffectiveStatusActive, "访问可用"
+}
+
+func (cp *controlPlane) ensureProxyPortAvailable(port int, excludeProxyID uint) error {
+	if port <= 0 {
+		return nil
+	}
+	conflict, err := cp.findProxyPortConflict(port, excludeProxyID)
+	if err != nil {
+		return err
+	}
+	if conflict != nil {
+		return fmt.Errorf("public port %d is already used by proxy %d", port, conflict.ID)
+	}
+	return nil
+}
+
+func (cp *controlPlane) findProxyPortConflict(port int, excludeProxyID uint) (*model.Proxy, error) {
+	if port <= 0 {
+		return nil, nil
+	}
+	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{})
+	if err != nil {
+		return nil, err
+	}
+	for _, proxy := range proxies {
+		if proxy.ID != excludeProxyID && proxy.Port == port {
+			return proxy, nil
+		}
+	}
+	return nil, nil
+}
+
+func (cp *controlPlane) allocateAvailableProxyPort(excludeProxyID uint) (int, error) {
+	const maxAttempts = 32
+	for i := 0; i < maxAttempts; i++ {
+		port, err := probeFreeTCPPort()
+		if err != nil {
+			return 0, err
+		}
+		conflict, err := cp.findProxyPortConflict(port, excludeProxyID)
+		if err != nil {
+			return 0, err
+		}
+		if conflict == nil {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("failed to allocate an available public port after %d attempts", maxAttempts)
+}
+
+func probeFreeTCPPort() (int, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, errors.New("allocated listener is not tcp")
+	}
+	return addr.Port, nil
+}
+
+type lifecycleDeleteTracker struct {
+	proxies      map[uint]bool
+	applications map[uint]bool
+	edges        map[uint64]bool
+	devices      map[uint]bool
+}
+
+func newLifecycleDeleteTracker() *lifecycleDeleteTracker {
+	return &lifecycleDeleteTracker{
+		proxies:      map[uint]bool{},
+		applications: map[uint]bool{},
+		edges:        map[uint64]bool{},
+		devices:      map[uint]bool{},
+	}
+}
+
+func (cp *controlPlane) deleteProxyCascade(proxyID uint, tracker *lifecycleDeleteTracker) error {
+	if tracker == nil {
+		tracker = newLifecycleDeleteTracker()
+	}
+	if tracker.proxies[proxyID] {
+		return nil
+	}
+	tracker.proxies[proxyID] = true
+
+	proxy, err := cp.repo.GetProxyByID(proxyID)
+	if err != nil {
+		return err
+	}
+	if err := cp.stopProxyRuntime(proxy); err != nil {
+		return fmt.Errorf("stop proxy %d runtime: %w", proxyID, err)
+	}
+	if err := cp.repo.DeleteFirewallRuleByProxyID(proxyID); err != nil {
+		return fmt.Errorf("delete firewall rule for proxy %d: %w", proxyID, err)
+	}
+	return cp.repo.DeleteProxy(proxyID)
+}
+
+func (cp *controlPlane) deleteApplicationCascade(applicationID uint, tracker *lifecycleDeleteTracker) error {
+	if tracker == nil {
+		tracker = newLifecycleDeleteTracker()
+	}
+	if tracker.applications[applicationID] {
+		return nil
+	}
+	tracker.applications[applicationID] = true
+
+	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{ApplicationIDs: []uint{applicationID}})
+	if err != nil {
+		return err
+	}
+	for _, proxy := range proxies {
+		if err := cp.deleteProxyCascade(proxy.ID, tracker); err != nil {
+			return err
+		}
+	}
+	return cp.repo.DeleteApplication(applicationID)
+}
+
+func (cp *controlPlane) deleteEdgeCascade(edgeID uint64, tracker *lifecycleDeleteTracker) error {
+	if tracker == nil {
+		tracker = newLifecycleDeleteTracker()
+	}
+	if tracker.edges[edgeID] {
+		return nil
+	}
+	tracker.edges[edgeID] = true
+
+	applications, err := cp.listApplicationsByEdgeID(edgeID)
+	if err != nil {
+		return err
+	}
+	for _, application := range applications {
+		if err := cp.deleteApplicationCascade(application.ID, tracker); err != nil {
+			return err
+		}
+	}
+	if err := cp.failActiveEdgeTasks(edgeID, "edge deleted"); err != nil {
+		return err
+	}
+	if err := cp.repo.DeleteAccessKeysByEdgeID(edgeID); err != nil {
+		return err
+	}
+	if cp.frontierBound != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := cp.frontierBound.KickEdge(ctx, edgeID); err != nil {
+			log.Warnf("kick deleted edge %d failed: %s", edgeID, err)
+		}
+		cancel()
+	}
+	if err := cp.repo.DeleteEdge(edgeID); err != nil {
+		return err
+	}
+	if err := cp.deleteEdgeOwnedDevicesCascade(edgeID, tracker); err != nil {
+		return err
+	}
+	if err := cp.repo.DeleteEdgeDevicesByEdgeID(edgeID, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cp *controlPlane) deleteEdgeOwnedDevicesCascade(edgeID uint64, tracker *lifecycleDeleteTracker) error {
+	edgeDevices, err := cp.repo.GetEdgeDevicesByEdgeID(edgeID, nil)
+	if err != nil {
+		return err
+	}
+	deviceIDs := map[uint]bool{}
+	for _, edgeDevice := range edgeDevices {
+		deviceIDs[edgeDevice.DeviceID] = true
+	}
+
+	for deviceID := range deviceIDs {
+		if tracker != nil && tracker.devices[deviceID] {
+			continue
+		}
+		relations, err := cp.repo.GetEdgeDevicesByDeviceID(deviceID, nil)
+		if err != nil {
+			return err
+		}
+		ownedByDeletingEdges := true
+		for _, relation := range relations {
+			if relation.EdgeID == edgeID {
+				continue
+			}
+			if tracker == nil || !tracker.edges[relation.EdgeID] {
+				ownedByDeletingEdges = false
+				break
+			}
+		}
+		if !ownedByDeletingEdges {
+			continue
+		}
+		if err := cp.deleteDeviceCascade(deviceID, tracker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cp *controlPlane) deleteDeviceCascade(deviceID uint, tracker *lifecycleDeleteTracker) error {
+	if tracker == nil {
+		tracker = newLifecycleDeleteTracker()
+	}
+	if tracker.devices[deviceID] {
+		return nil
+	}
+	tracker.devices[deviceID] = true
+
+	hostType := model.EdgeDeviceRelationHost
+	edgeDevices, err := cp.repo.GetEdgeDevicesByDeviceID(deviceID, &hostType)
+	if err != nil {
+		return err
+	}
+	for _, edgeDevice := range edgeDevices {
+		if err := cp.deleteEdgeCascade(edgeDevice.EdgeID, tracker); err != nil {
+			return err
+		}
+	}
+
+	applications, err := cp.repo.ListApplications(&dao.ListApplicationsQuery{DeviceIDs: []uint{deviceID}})
+	if err != nil {
+		return err
+	}
+	for _, application := range applications {
+		if err := cp.deleteApplicationCascade(application.ID, tracker); err != nil {
+			return err
+		}
+	}
+	return cp.repo.DeleteDevice(deviceID)
+}
+
+func (cp *controlPlane) listApplicationsByEdgeID(edgeID uint64) ([]*model.Application, error) {
+	applications, err := cp.repo.ListApplications(&dao.ListApplicationsQuery{})
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]*model.Application, 0)
+	for _, application := range applications {
+		for _, appEdgeID := range application.EdgeIDs {
+			if uint64(appEdgeID) == edgeID {
+				filtered = append(filtered, application)
+				break
+			}
+		}
+	}
+	return filtered, nil
+}
+
+func (cp *controlPlane) listProxiesByEdgeID(edgeID uint64) ([]*model.Proxy, error) {
+	applications, err := cp.listApplicationsByEdgeID(edgeID)
+	if err != nil {
+		return nil, err
+	}
+	if len(applications) == 0 {
+		return []*model.Proxy{}, nil
+	}
+	applicationIDs := make([]uint, 0, len(applications))
+	applicationMap := make(map[uint]*model.Application, len(applications))
+	for _, application := range applications {
+		applicationIDs = append(applicationIDs, application.ID)
+		applicationMap[application.ID] = application
+	}
+	proxies, err := cp.repo.ListProxies(&dao.ListProxiesQuery{ApplicationIDs: applicationIDs})
+	if err != nil {
+		return nil, err
+	}
+	for _, proxy := range proxies {
+		proxy.Application = applicationMap[proxy.ApplicationID]
+	}
+	return proxies, nil
+}
+
+func (cp *controlPlane) startAndPersistProxyRuntime(proxy *model.Proxy) error {
+	if proxy == nil {
+		return nil
+	}
+	oldPort := proxy.Port
+	if err := cp.startProxyRuntime(proxy, proxy.Application); err != nil {
+		return err
+	}
+	if oldPort == 0 && proxy.Port > 0 {
+		if err := cp.repo.UpdateProxy(proxy); err != nil {
+			_ = cp.stopProxyRuntime(proxy)
+			return err
+		}
+	}
+	return nil
+}
+
+func (cp *controlPlane) stopEdgeProxies(edgeID uint64) error {
+	proxies, err := cp.listProxiesByEdgeID(edgeID)
+	if err != nil {
+		return err
+	}
+	for _, proxy := range proxies {
+		if proxy.Status != model.ProxyStatusRunning {
+			continue
+		}
+		if err := cp.stopProxyRuntime(proxy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cp *controlPlane) startEdgeProxies(edgeID uint64) error {
+	proxies, err := cp.listProxiesByEdgeID(edgeID)
+	if err != nil {
+		return err
+	}
+	started := make([]*model.Proxy, 0, len(proxies))
+	for _, proxy := range proxies {
+		if proxy.Status != model.ProxyStatusRunning {
+			continue
+		}
+		if err := cp.startAndPersistProxyRuntime(proxy); err != nil {
+			for _, startedProxy := range started {
+				_ = cp.stopProxyRuntime(startedProxy)
+			}
+			return err
+		}
+		started = append(started, proxy)
+	}
+	return nil
+}
+
+func (cp *controlPlane) failActiveEdgeTasks(edgeID uint64, reason string) error {
+	tasks, err := cp.repo.ListTasks(&dao.ListTasksQuery{
+		EdgeID: uint(edgeID),
+		Status: []model.TaskStatus{
+			model.TaskStatusPending,
+			model.TaskStatusRunning,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	for _, task := range tasks {
+		if err := cp.repo.UpdateTaskError(task.ID, reason); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/liaison/manager/controlplane/lifecycle_test.go
+++ b/pkg/liaison/manager/controlplane/lifecycle_test.go
@@ -1,0 +1,498 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/liaisonio/liaison/api/v1"
+	"github.com/liaisonio/liaison/pkg/liaison/config"
+	"github.com/liaisonio/liaison/pkg/liaison/repo"
+	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
+	"github.com/liaisonio/liaison/pkg/proto"
+)
+
+type fakeProxyManager struct {
+	created   map[int]*proto.Proxy
+	deleted   []int
+	createErr error
+	deleteErr error
+}
+
+func newFakeProxyManager() *fakeProxyManager {
+	return &fakeProxyManager{created: map[int]*proto.Proxy{}}
+}
+
+func (f *fakeProxyManager) CreateProxy(_ context.Context, proxy *proto.Proxy) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if proxy.ProxyPort == 0 {
+		proxy.ProxyPort = 39001
+	}
+	copied := *proxy
+	f.created[proxy.ID] = &copied
+	return nil
+}
+
+func (f *fakeProxyManager) DeleteProxy(_ context.Context, id int) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.created, id)
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+type fakeFirewallManager struct {
+	allowed map[int][]string
+	revoked []int
+}
+
+func newFakeFirewallManager() *fakeFirewallManager {
+	return &fakeFirewallManager{allowed: map[int][]string{}}
+}
+
+func (f *fakeFirewallManager) Allow(proxyID int, cidrs []string) error {
+	f.allowed[proxyID] = append([]string(nil), cidrs...)
+	return nil
+}
+
+func (f *fakeFirewallManager) Revoke(proxyID int) {
+	delete(f.allowed, proxyID)
+	f.revoked = append(f.revoked, proxyID)
+}
+
+func newTestControlPlane(t *testing.T) (*controlPlane, repo.Repo) {
+	t.Helper()
+	conf := &config.Configuration{}
+	conf.Manager.DB = t.TempDir() + "/liaison.db"
+	conf.Manager.ServerURL = "https://example.test"
+
+	r, err := repo.NewRepo(conf)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	cp := &controlPlane{conf: conf, repo: r}
+	return cp, r
+}
+
+func createTestEdgeApplication(t *testing.T, r repo.Repo) (*model.Edge, *model.Application) {
+	t.Helper()
+	edge := &model.Edge{
+		Name:   "edge-1",
+		Status: model.EdgeStatusRunning,
+		Online: model.EdgeOnlineStatusOnline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+	application := &model.Application{
+		Name:            "app-1",
+		IP:              "127.0.0.1",
+		Port:            8080,
+		ApplicationType: model.ApplicationTypeTCP,
+		EdgeIDs:         model.UintSlice{uint(edge.ID)},
+	}
+	if err := r.CreateApplication(application); err != nil {
+		t.Fatalf("create application: %v", err)
+	}
+	return edge, application
+}
+
+func createTestDevice(t *testing.T, r repo.Repo, name string) *model.Device {
+	t.Helper()
+	device := &model.Device{
+		Fingerprint: name + "-fingerprint",
+		Name:        name,
+		HostName:    name + ".local",
+		Online:      model.DeviceOnlineStatusOnline,
+		HeartbeatAt: time.Now(),
+		OS:          "test-os",
+	}
+	if err := r.CreateDevice(device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+	return device
+}
+
+func TestEdgeStopKeepsProxyEnabledButStopsRuntime(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	edge, application := createTestEdgeApplication(t, r)
+	created, err := cp.CreateProxy(context.Background(), &v1.CreateProxyRequest{
+		ApplicationId: uint64(application.ID),
+		Name:          "entry-1",
+		Port:          32001,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	if len(pm.created) != 1 {
+		t.Fatalf("expected one running proxy, got %d", len(pm.created))
+	}
+
+	if _, err := cp.UpdateEdge(context.Background(), &v1.UpdateEdgeRequest{
+		Id:     uint64(edge.ID),
+		Status: int32(model.EdgeStatusStopped),
+	}); err != nil {
+		t.Fatalf("stop edge: %v", err)
+	}
+	updatedEdge, err := r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updatedEdge.Online != model.EdgeOnlineStatusOnline {
+		t.Fatalf("edge online changed to %d, want online state to stay independent", updatedEdge.Online)
+	}
+
+	proxy, err := r.GetProxyByID(uint(created.Data.Id))
+	if err != nil {
+		t.Fatalf("get proxy: %v", err)
+	}
+	if proxy.Status != model.ProxyStatusRunning {
+		t.Fatalf("proxy status changed to %d, want running", proxy.Status)
+	}
+	if len(pm.created) != 0 {
+		t.Fatalf("runtime proxy still running after edge stop")
+	}
+
+	listed, err := cp.ListProxies(context.Background(), &v1.ListProxiesRequest{Page: -1, PageSize: -1})
+	if err != nil {
+		t.Fatalf("list proxies: %v", err)
+	}
+	if got := listed.Data.Proxies[0].EffectiveStatus; got != proxyEffectiveStatusEdgeStopped {
+		t.Fatalf("effective status = %q, want %q", got, proxyEffectiveStatusEdgeStopped)
+	}
+	if got := listed.Data.Proxies[0].EffectiveStatusMessage; got != "连接器已禁用" {
+		t.Fatalf("effective status message = %q, want 连接器已禁用", got)
+	}
+
+	if _, err := cp.UpdateEdge(context.Background(), &v1.UpdateEdgeRequest{
+		Id:     uint64(edge.ID),
+		Status: int32(model.EdgeStatusRunning),
+	}); err != nil {
+		t.Fatalf("start edge: %v", err)
+	}
+	if len(pm.created) != 1 {
+		t.Fatalf("runtime proxy was not restored after edge start")
+	}
+}
+
+func TestStoppedProxyEffectiveStatusMessage(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+
+	_, application := createTestEdgeApplication(t, r)
+	proxy := &model.Proxy{
+		Name:          "entry-1",
+		Status:        model.ProxyStatusStopped,
+		ApplicationID: application.ID,
+		Port:          32001,
+	}
+	if err := r.CreateProxy(proxy); err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	listed, err := cp.ListProxies(context.Background(), &v1.ListProxiesRequest{Page: -1, PageSize: -1})
+	if err != nil {
+		t.Fatalf("list proxies: %v", err)
+	}
+	if got := listed.Data.Proxies[0].EffectiveStatus; got != proxyEffectiveStatusStopped {
+		t.Fatalf("effective status = %q, want %q", got, proxyEffectiveStatusStopped)
+	}
+	if got := listed.Data.Proxies[0].EffectiveStatusMessage; got != "访问未启用" {
+		t.Fatalf("effective status message = %q, want 访问未启用", got)
+	}
+}
+
+func TestDeleteApplicationCascadesProxyAndFirewall(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	fw := newFakeFirewallManager()
+	cp.RegisterProxyManager(pm)
+	cp.RegisterFirewallManager(fw)
+
+	_, application := createTestEdgeApplication(t, r)
+	created, err := cp.CreateProxy(context.Background(), &v1.CreateProxyRequest{
+		ApplicationId: uint64(application.ID),
+		Name:          "entry-1",
+		Port:          32002,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	if _, err := cp.UpsertProxyFirewall(context.Background(), uint(created.Data.Id), []string{"203.0.113.1/32"}); err != nil {
+		t.Fatalf("upsert firewall: %v", err)
+	}
+
+	if _, err := cp.DeleteApplication(context.Background(), &v1.DeleteApplicationRequest{Id: uint64(application.ID)}); err != nil {
+		t.Fatalf("delete application: %v", err)
+	}
+	if _, err := r.GetProxyByID(uint(created.Data.Id)); err == nil {
+		t.Fatalf("proxy still exists after application deletion")
+	}
+	if rule, err := r.GetFirewallRuleByProxyID(uint(created.Data.Id)); err != nil {
+		t.Fatalf("get firewall rule: %v", err)
+	} else if rule != nil {
+		t.Fatalf("firewall rule still exists after application deletion")
+	}
+	if len(pm.created) != 0 {
+		t.Fatalf("runtime proxy still running after application deletion")
+	}
+}
+
+func TestDeleteEdgeCascadesOwnedDevices(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+
+	edge, _ := createTestEdgeApplication(t, r)
+	host := createTestDevice(t, r, "host-device")
+	discovered := createTestDevice(t, r, "discovered-device")
+	hostType := model.EdgeDeviceRelationHost
+	discoveredType := model.EdgeDeviceRelationDiscovered
+	if err := r.CreateEdgeDevice(&model.EdgeDevice{EdgeID: uint64(edge.ID), DeviceID: host.ID, Type: hostType}); err != nil {
+		t.Fatalf("create host relation: %v", err)
+	}
+	if err := r.CreateEdgeDevice(&model.EdgeDevice{EdgeID: uint64(edge.ID), DeviceID: discovered.ID, Type: discoveredType}); err != nil {
+		t.Fatalf("create discovered relation: %v", err)
+	}
+
+	if _, err := cp.DeleteEdge(context.Background(), &v1.DeleteEdgeRequest{Id: uint64(edge.ID)}); err != nil {
+		t.Fatalf("delete edge: %v", err)
+	}
+	if _, err := r.GetDeviceByID(host.ID); err == nil {
+		t.Fatalf("host device still exists after edge deletion")
+	}
+	if _, err := r.GetDeviceByID(discovered.ID); err == nil {
+		t.Fatalf("discovered device still exists after edge deletion")
+	}
+	if relations, err := r.GetEdgeDevicesByEdgeID(uint64(edge.ID), nil); err != nil {
+		t.Fatalf("get edge device relations: %v", err)
+	} else if len(relations) != 0 {
+		t.Fatalf("edge device relations still exist after edge deletion: %d", len(relations))
+	}
+}
+
+func TestDeleteEdgeKeepsDevicesSharedWithAnotherEdge(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+
+	edge, _ := createTestEdgeApplication(t, r)
+	otherEdge := &model.Edge{
+		Name:   "edge-2",
+		Status: model.EdgeStatusRunning,
+		Online: model.EdgeOnlineStatusOnline,
+	}
+	if err := r.CreateEdge(otherEdge); err != nil {
+		t.Fatalf("create other edge: %v", err)
+	}
+	device := createTestDevice(t, r, "shared-device")
+	discoveredType := model.EdgeDeviceRelationDiscovered
+	if err := r.CreateEdgeDevice(&model.EdgeDevice{EdgeID: uint64(edge.ID), DeviceID: device.ID, Type: discoveredType}); err != nil {
+		t.Fatalf("create first relation: %v", err)
+	}
+	if err := r.CreateEdgeDevice(&model.EdgeDevice{EdgeID: uint64(otherEdge.ID), DeviceID: device.ID, Type: discoveredType}); err != nil {
+		t.Fatalf("create second relation: %v", err)
+	}
+
+	if _, err := cp.DeleteEdge(context.Background(), &v1.DeleteEdgeRequest{Id: uint64(edge.ID)}); err != nil {
+		t.Fatalf("delete edge: %v", err)
+	}
+	if _, err := r.GetDeviceByID(device.ID); err != nil {
+		t.Fatalf("shared device was deleted: %v", err)
+	}
+	relations, err := r.GetEdgeDevicesByDeviceID(device.ID, nil)
+	if err != nil {
+		t.Fatalf("get device relations: %v", err)
+	}
+	if len(relations) != 1 || relations[0].EdgeID != uint64(otherEdge.ID) {
+		t.Fatalf("shared device relations = %+v, want only edge %d", relations, otherEdge.ID)
+	}
+}
+
+func TestEdgeStopDoesNotPersistStoppedWhenRuntimeStopFails(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	edge, application := createTestEdgeApplication(t, r)
+	if _, err := cp.CreateProxy(context.Background(), &v1.CreateProxyRequest{
+		ApplicationId: uint64(application.ID),
+		Name:          "entry-1",
+		Port:          32003,
+	}); err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	pm.deleteErr = errors.New("listener close failed")
+	if _, err := cp.UpdateEdge(context.Background(), &v1.UpdateEdgeRequest{
+		Id:     uint64(edge.ID),
+		Status: int32(model.EdgeStatusStopped),
+	}); err == nil {
+		t.Fatalf("expected stop edge error")
+	}
+
+	updatedEdge, err := r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updatedEdge.Status != model.EdgeStatusRunning {
+		t.Fatalf("edge status = %d, want running after failed stop", updatedEdge.Status)
+	}
+	if len(pm.created) != 1 {
+		t.Fatalf("runtime proxy should still be tracked after failed stop")
+	}
+}
+
+func TestDeleteProxyKeepsRecordWhenRuntimeStopFails(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	_, application := createTestEdgeApplication(t, r)
+	created, err := cp.CreateProxy(context.Background(), &v1.CreateProxyRequest{
+		ApplicationId: uint64(application.ID),
+		Name:          "entry-1",
+		Port:          32004,
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	pm.deleteErr = errors.New("listener close failed")
+	if _, err := cp.DeleteProxy(context.Background(), &v1.DeleteProxyRequest{Id: created.Data.Id}); err == nil {
+		t.Fatalf("expected delete proxy error")
+	}
+	if _, err := r.GetProxyByID(uint(created.Data.Id)); err != nil {
+		t.Fatalf("proxy record should remain after failed runtime stop: %v", err)
+	}
+}
+
+func TestStoppedEdgeAutoPortIsPersistedWhenEdgeStarts(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	edge, application := createTestEdgeApplication(t, r)
+	edge.Status = model.EdgeStatusStopped
+	edge.Online = model.EdgeOnlineStatusOffline
+	if err := r.UpdateEdge(edge); err != nil {
+		t.Fatalf("stop edge in db: %v", err)
+	}
+
+	created, err := cp.CreateProxy(context.Background(), &v1.CreateProxyRequest{
+		ApplicationId: uint64(application.ID),
+		Name:          "entry-1",
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	if created.Data.Port == 0 {
+		t.Fatalf("created proxy port = 0, want reserved public port while edge is stopped")
+	}
+	if len(pm.created) != 0 {
+		t.Fatalf("runtime should not start while edge is stopped")
+	}
+
+	if _, err := cp.UpdateEdge(context.Background(), &v1.UpdateEdgeRequest{
+		Id:     uint64(edge.ID),
+		Status: int32(model.EdgeStatusRunning),
+	}); err != nil {
+		t.Fatalf("start edge: %v", err)
+	}
+	proxy, err := r.GetProxyByID(uint(created.Data.Id))
+	if err != nil {
+		t.Fatalf("get proxy: %v", err)
+	}
+	if proxy.Port != int(created.Data.Port) {
+		t.Fatalf("proxy port = %d, want reserved port %d", proxy.Port, created.Data.Port)
+	}
+	if len(pm.created) != 1 {
+		t.Fatalf("runtime proxy was not started after edge start")
+	}
+	if got := pm.created[int(created.Data.Id)].ProxyPort; got != int(created.Data.Port) {
+		t.Fatalf("runtime proxy port = %d, want reserved port %d", got, created.Data.Port)
+	}
+}
+
+func TestRestoreProxyListenersPersistsAutoAllocatedPort(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	_, application := createTestEdgeApplication(t, r)
+	proxy := &model.Proxy{
+		Name:          "entry-1",
+		Status:        model.ProxyStatusRunning,
+		ApplicationID: application.ID,
+		Port:          0,
+	}
+	if err := r.CreateProxy(proxy); err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	if err := cp.RestoreProxyListeners(); err != nil {
+		t.Fatalf("restore proxy listeners: %v", err)
+	}
+	restored, err := r.GetProxyByID(proxy.ID)
+	if err != nil {
+		t.Fatalf("get proxy: %v", err)
+	}
+	if restored.Port != 39001 {
+		t.Fatalf("restored proxy port = %d, want allocated port persisted", restored.Port)
+	}
+	if len(pm.created) != 1 {
+		t.Fatalf("runtime proxy was not restored")
+	}
+}
+
+func TestRestoreProxyListenersRejectsAutoPortConflict(t *testing.T) {
+	cp, r := newTestControlPlane(t)
+	defer r.Close()
+	pm := newFakeProxyManager()
+	cp.RegisterProxyManager(pm)
+
+	_, application := createTestEdgeApplication(t, r)
+	reserved := &model.Proxy{
+		Name:          "reserved",
+		Status:        model.ProxyStatusStopped,
+		ApplicationID: application.ID,
+		Port:          39001,
+	}
+	if err := r.CreateProxy(reserved); err != nil {
+		t.Fatalf("create reserved proxy: %v", err)
+	}
+	legacy := &model.Proxy{
+		Name:          "legacy",
+		Status:        model.ProxyStatusRunning,
+		ApplicationID: application.ID,
+		Port:          0,
+	}
+	if err := r.CreateProxy(legacy); err != nil {
+		t.Fatalf("create legacy proxy: %v", err)
+	}
+
+	if err := cp.RestoreProxyListeners(); err == nil {
+		t.Fatalf("expected restore error for auto-assigned port conflict")
+	}
+	restored, err := r.GetProxyByID(legacy.ID)
+	if err != nil {
+		t.Fatalf("get legacy proxy: %v", err)
+	}
+	if restored.Port != 0 {
+		t.Fatalf("legacy proxy port = %d, want 0 after failed restore", restored.Port)
+	}
+	if len(pm.created) != 0 {
+		t.Fatalf("conflicting runtime proxy should be stopped")
+	}
+}

--- a/pkg/liaison/manager/controlplane/proxy.go
+++ b/pkg/liaison/manager/controlplane/proxy.go
@@ -23,21 +23,28 @@ func (cp *controlPlane) RegisterFirewallManager(firewallManager proto.FirewallMa
 }
 
 func (cp *controlPlane) CreateProxy(_ context.Context, req *v1.CreateProxyRequest) (*v1.CreateProxyResponse, error) {
-	// 查看是否有冲突
-	// 获取application
 	application, err := cp.repo.GetApplicationByID(uint(req.ApplicationId))
 	if err != nil {
 		log.Warnf("application %d not found", req.ApplicationId)
 		return nil, err
 	}
-
-	// 如果端口为空或0，设置为0让系统自动分配
-	requestedPort := int(req.Port)
-	if requestedPort == 0 {
-		requestedPort = 0 // 明确设置为0，让系统自动分配
+	edge, err := cp.validateProxyApplication(application)
+	if err != nil {
+		return nil, err
 	}
 
-	// 创建Proxy持久化（如果端口为0，先保存0，后续会更新）
+	requestedPort := int(req.Port)
+	if requestedPort > 0 {
+		if err := cp.ensureProxyPortAvailable(requestedPort, 0); err != nil {
+			return nil, err
+		}
+	} else if edge.Status == model.EdgeStatusStopped {
+		requestedPort, err = cp.allocateAvailableProxyPort(0)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	proxy := &model.Proxy{
 		Name:          req.Name,
 		Status:        model.ProxyStatusRunning,
@@ -50,43 +57,20 @@ func (cp *controlPlane) CreateProxy(_ context.Context, req *v1.CreateProxyReques
 		log.Warnf("failed to create proxy: %s", err)
 		return nil, err
 	}
+	proxy.Application = application
 
-	// 创建Proxy（如果端口为0，系统会自动分配）
-	// 如果是 HTTP 应用，默认使用 HTTPS
-	useHTTPS := false
-	if application.ApplicationType == model.ApplicationTypeHTTP {
-		useHTTPS = true
-	}
-
-	protoproxy := &proto.Proxy{
-		ID:              int(proxy.ID),
-		Name:            proxy.Name,
-		ProxyPort:       requestedPort, // 如果为0，系统会自动分配
-		EdgeID:          uint64(application.EdgeIDs[0]),
-		ApplicationID:   application.ID,
-		Dst:             fmt.Sprintf("%s:%d", application.IP, application.Port),
-		ApplicationType: string(application.ApplicationType),
-		UseHTTPS:        useHTTPS,
-	}
-	err = cp.proxyManager.CreateProxy(context.Background(), protoproxy)
-	if err != nil {
-		log.Errorf("failed to create proxy listener: %s", err)
-		// 如果创建失败，删除数据库记录
-		_ = cp.repo.DeleteProxy(proxy.ID)
-		return nil, err
-	}
-
-	// 如果端口为0，系统已经分配了端口，更新数据库中的端口
-	if requestedPort == 0 {
-		actualPort := protoproxy.ProxyPort
-		if actualPort > 0 {
-			proxy.Port = actualPort
-			err = cp.repo.UpdateProxy(proxy)
-			if err != nil {
-				log.Errorf("failed to update proxy port: %s", err)
-				// 即使更新失败，代理已经创建成功，继续返回成功
-			} else {
-				log.Infof("proxy %d: updated port to %d (system allocated)", proxy.ID, actualPort)
+	if edge.Status == model.EdgeStatusRunning {
+		err = cp.startProxyRuntime(proxy, application)
+		if err != nil {
+			log.Errorf("failed to create proxy listener: %s", err)
+			_ = cp.repo.DeleteProxy(proxy.ID)
+			return nil, err
+		}
+		if requestedPort == 0 && proxy.Port > 0 {
+			if err = cp.repo.UpdateProxy(proxy); err != nil {
+				_ = cp.stopProxyRuntime(proxy)
+				_ = cp.repo.DeleteProxy(proxy.ID)
+				return nil, err
 			}
 		}
 	}
@@ -119,22 +103,26 @@ func (cp *controlPlane) ListProxies(_ context.Context, req *v1.ListProxiesReques
 	if err != nil {
 		return nil, err
 	}
-	ids := make([]uint, len(proxies))
-	for i, proxy := range proxies {
-		ids[i] = proxy.ApplicationID
+	ids := make([]uint, 0, len(proxies))
+	seenIDs := make(map[uint]bool)
+	for _, proxy := range proxies {
+		if !seenIDs[proxy.ApplicationID] {
+			ids = append(ids, proxy.ApplicationID)
+			seenIDs[proxy.ApplicationID] = true
+		}
 	}
-	// list applications
-	applications, err := cp.repo.ListApplications(&dao.ListApplicationsQuery{
-		Query: dao.Query{
-			Page:     int(req.Page),
-			PageSize: int(req.PageSize),
-			Order:    "id",
-			Desc:     true,
-		},
-		IDs: ids,
-	})
-	if err != nil {
-		return nil, err
+	var applications []*model.Application
+	if len(ids) > 0 {
+		applications, err = cp.repo.ListApplications(&dao.ListApplicationsQuery{
+			Query: dao.Query{
+				Order: "id",
+				Desc:  true,
+			},
+			IDs: ids,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	// add applications to proxies
 	// 创建一个 map 来快速查找 application
@@ -161,27 +149,26 @@ func (cp *controlPlane) ListProxies(_ context.Context, req *v1.ListProxiesReques
 	}, nil
 }
 
-// 更新代理，不允许更新代理端口
 func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyRequest) (*v1.UpdateProxyResponse, error) {
 	proxy, err := cp.repo.GetProxyByID(uint(req.Id))
 	if err != nil {
 		return nil, err
 	}
 
-	// 保存旧状态
-	oldStatus := proxy.Status
+	oldProxy := *proxy
 
-	// 更新名称
 	if req.Name != "" {
 		proxy.Name = req.Name
 	}
-
-	// 更新描述
 	if req.Description != "" {
 		proxy.Description = req.Description
 	}
-
-	// 更新状态
+	if req.Port > 0 && int(req.Port) != proxy.Port {
+		if err := cp.ensureProxyPortAvailable(int(req.Port), proxy.ID); err != nil {
+			return nil, err
+		}
+		proxy.Port = int(req.Port)
+	}
 	if req.Status != "" {
 		switch req.Status {
 		case "running":
@@ -189,52 +176,62 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 		case "stopped":
 			proxy.Status = model.ProxyStatusStopped
 		default:
-			log.Warnf("unknown proxy status: %s", req.Status)
+			return nil, fmt.Errorf("unknown proxy status: %s", req.Status)
 		}
 	}
 
-	// 如果状态发生变化，需要调用 ProxyManager
-	if oldStatus != proxy.Status {
-		// 获取 application 信息（用于启动代理时）
-		application, err := cp.repo.GetApplicationByID(proxy.ApplicationID)
+	statusChanged := oldProxy.Status != proxy.Status
+	portChanged := oldProxy.Port != proxy.Port
+	runtimeChanged := statusChanged || portChanged
+
+	var application *model.Application
+	var applicationErr error
+	if proxy.Status == model.ProxyStatusRunning || oldProxy.Status == model.ProxyStatusRunning {
+		application, applicationErr = cp.repo.GetApplicationByID(proxy.ApplicationID)
+	}
+	if proxy.Status == model.ProxyStatusRunning && applicationErr != nil {
+		return nil, applicationErr
+	}
+
+	oldRuntimeEligible := false
+	if oldProxy.Status == model.ProxyStatusRunning && applicationErr == nil {
+		oldRuntimeEligible, _ = cp.proxyRuntimeEligible(&oldProxy, application)
+	}
+	newRuntimeEligible := false
+	if proxy.Status == model.ProxyStatusRunning {
+		newRuntimeEligible, err = cp.proxyRuntimeEligible(proxy, application)
 		if err != nil {
-			log.Warnf("application %d not found", proxy.ApplicationID)
 			return nil, err
 		}
+	}
 
-		if proxy.Status == model.ProxyStatusStopped {
-			// 停止代理：调用 DeleteProxy（这会停止代理但不会删除数据库记录）
-			err = cp.proxyManager.DeleteProxy(context.Background(), int(proxy.ID))
-			if err != nil {
-				log.Errorf("failed to stop proxy: %s", err)
-				return nil, err
-			}
-		} else if proxy.Status == model.ProxyStatusRunning {
-			// 启动代理：调用 CreateProxy
-			// 如果是 HTTP 应用，默认使用 HTTPS
-			useHTTPS := false
-			if application.ApplicationType == model.ApplicationTypeHTTP {
-				useHTTPS = true
-			}
-			err = cp.proxyManager.CreateProxy(context.Background(), &proto.Proxy{
-				ID:              int(proxy.ID),
-				Name:            proxy.Name,
-				ProxyPort:       proxy.Port,
-				EdgeID:          uint64(application.EdgeIDs[0]),
-				Dst:             fmt.Sprintf("%s:%d", application.IP, application.Port),
-				ApplicationType: string(application.ApplicationType),
-				UseHTTPS:        useHTTPS,
-			})
-			if err != nil {
-				log.Errorf("failed to start proxy: %s", err)
-				return nil, err
-			}
+	if runtimeChanged && oldProxy.Status == model.ProxyStatusRunning {
+		if err := cp.stopProxyRuntime(&oldProxy); err != nil {
+			log.Errorf("failed to stop proxy: %s", err)
+			return nil, err
 		}
 	}
 
-	// 更新数据库
+	startedNewRuntime := false
+	if runtimeChanged && newRuntimeEligible {
+		if err := cp.startProxyRuntime(proxy, application); err != nil {
+			if oldRuntimeEligible {
+				_ = cp.startProxyRuntime(&oldProxy, application)
+			}
+			log.Errorf("failed to start proxy: %s", err)
+			return nil, err
+		}
+		startedNewRuntime = true
+	}
+
 	err = cp.repo.UpdateProxy(proxy)
 	if err != nil {
+		if startedNewRuntime {
+			_ = cp.stopProxyRuntime(proxy)
+		}
+		if runtimeChanged && oldRuntimeEligible {
+			_ = cp.startProxyRuntime(&oldProxy, application)
+		}
 		return nil, err
 	}
 
@@ -243,6 +240,10 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 	if err != nil {
 		return nil, err
 	}
+	if application == nil {
+		application, _ = cp.repo.GetApplicationByID(updatedProxy.ApplicationID)
+	}
+	updatedProxy.Application = application
 
 	return &v1.UpdateProxyResponse{
 		Code:    200,
@@ -252,22 +253,7 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 }
 
 func (cp *controlPlane) DeleteProxy(_ context.Context, req *v1.DeleteProxyRequest) (*v1.DeleteProxyResponse, error) {
-	proxyID := uint(req.Id)
-
-	// 停数据面（幂等）。没有在运行或 proxyManager 未注册时直接跳过。
-	if err := cp.proxyManager.DeleteProxy(context.Background(), int(proxyID)); err != nil {
-		log.Warnf("delete proxy runtime %d: %s", proxyID, err)
-	}
-	// 清理数据面防火墙状态
-	if cp.firewallManager != nil {
-		cp.firewallManager.Revoke(int(proxyID))
-	}
-	// 删除持久化的防火墙规则（如有）
-	if err := cp.repo.DeleteFirewallRuleByProxyID(proxyID); err != nil {
-		log.Warnf("delete firewall rule for proxy %d: %s", proxyID, err)
-	}
-	// 删除 proxy 本身
-	if err := cp.repo.DeleteProxy(proxyID); err != nil {
+	if err := cp.deleteProxyCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
 	return &v1.DeleteProxyResponse{
@@ -290,16 +276,8 @@ func (cp *controlPlane) transformProxy(proxy *model.Proxy) *v1.Proxy {
 		application = transformApplication(proxy.Application)
 	}
 
-	// 将 ProxyStatus 转换为字符串
-	var status string
-	switch proxy.Status {
-	case model.ProxyStatusRunning:
-		status = "running"
-	case model.ProxyStatusStopped:
-		status = "stopped"
-	default:
-		status = "unknown"
-	}
+	status := proxyStatusString(proxy.Status)
+	effectiveStatus, effectiveStatusMessage := cp.proxyEffectiveStatus(proxy, proxy.Application)
 
 	// 生成访问地址 —— server_url 形如 https://<host>[:<manager_port>]，
 	// 这里只需要 host 部分,再拼 entry 自己的端口。
@@ -326,14 +304,27 @@ func (cp *controlPlane) transformProxy(proxy *model.Proxy) *v1.Proxy {
 	}
 
 	return &v1.Proxy{
-		Id:          uint64(proxy.ID),
-		Name:        proxy.Name,
-		Port:        int32(proxy.Port),
-		Status:      status,
-		Application: application,
-		Description: proxy.Description,
-		CreatedAt:   proxy.CreatedAt.Format(time.DateTime),
-		UpdatedAt:   proxy.UpdatedAt.Format(time.DateTime),
-		AccessUrl:   accessURL,
+		Id:                     uint64(proxy.ID),
+		Name:                   proxy.Name,
+		Port:                   int32(proxy.Port),
+		Status:                 status,
+		Application:            application,
+		Description:            proxy.Description,
+		CreatedAt:              proxy.CreatedAt.Format(time.DateTime),
+		UpdatedAt:              proxy.UpdatedAt.Format(time.DateTime),
+		AccessUrl:              accessURL,
+		EffectiveStatus:        effectiveStatus,
+		EffectiveStatusMessage: effectiveStatusMessage,
+	}
+}
+
+func proxyStatusString(status model.ProxyStatus) string {
+	switch status {
+	case model.ProxyStatusRunning:
+		return "running"
+	case model.ProxyStatusStopped:
+		return "stopped"
+	default:
+		return "unknown"
 	}
 }

--- a/pkg/liaison/manager/frontierbound/auth.go
+++ b/pkg/liaison/manager/frontierbound/auth.go
@@ -1,0 +1,29 @@
+package frontierbound
+
+import (
+	"fmt"
+
+	"github.com/singchia/geminio"
+)
+
+func (fb *frontierBound) requireRegisteredEdge(req geminio.Request) (uint64, error) {
+	edgeID := req.ClientID()
+	if edgeID == 0 {
+		return 0, fmt.Errorf("missing edge client id")
+	}
+	if _, err := fb.repo.GetEdge(edgeID); err != nil {
+		return 0, fmt.Errorf("edge %d is not registered: %w", edgeID, err)
+	}
+	return edgeID, nil
+}
+
+func (fb *frontierBound) requireRequestEdge(req geminio.Request, payloadEdgeID uint64) (uint64, error) {
+	edgeID, err := fb.requireRegisteredEdge(req)
+	if err != nil {
+		return 0, err
+	}
+	if payloadEdgeID != 0 && payloadEdgeID != edgeID {
+		return 0, fmt.Errorf("edge id mismatch: connection edge %d, payload edge %d", edgeID, payloadEdgeID)
+	}
+	return edgeID, nil
+}

--- a/pkg/liaison/manager/frontierbound/controlplane.go
+++ b/pkg/liaison/manager/frontierbound/controlplane.go
@@ -1,0 +1,58 @@
+package frontierbound
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// KickEdge asks Frontier to close the currently connected Edge, if any.
+func (fb *frontierBound) KickEdge(ctx context.Context, edgeID uint64) error {
+	controlPlaneURL := normalizeControlPlaneURL(fb.controlPlaneURL)
+	if controlPlaneURL == "" {
+		return nil
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/edges/%d", strings.TrimRight(controlPlaneURL, "/"), edgeID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	client := fb.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		fb.forgetEdge(edgeID)
+		return nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("kick edge %d via frontier controlplane: status %d: %s", edgeID, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	fb.forgetEdge(edgeID)
+	return nil
+}
+
+func normalizeControlPlaneURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(raw); err == nil && parsed.Scheme != "" {
+		return raw
+	}
+	return "http://" + raw
+}

--- a/pkg/liaison/manager/frontierbound/device.go
+++ b/pkg/liaison/manager/frontierbound/device.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 
 	"github.com/jumboframes/armorigo/log"
-	"github.com/singchia/geminio"
 	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
 	"github.com/liaisonio/liaison/pkg/proto"
+	"github.com/singchia/geminio"
 	"gorm.io/gorm"
 )
 
@@ -16,6 +16,11 @@ import (
 func (fb *frontierBound) reportDeviceUsage(ctx context.Context, req geminio.Request, rsp geminio.Response) {
 	var usage proto.DeviceUsage
 	if err := json.Unmarshal(req.Data(), &usage); err != nil {
+		rsp.SetError(err)
+		return
+	}
+	edgeID, err := fb.requireRegisteredEdge(req)
+	if err != nil {
 		rsp.SetError(err)
 		return
 	}
@@ -35,25 +40,8 @@ func (fb *frontierBound) reportDeviceUsage(ctx context.Context, req geminio.Requ
 		return
 	}
 
-	// 更新 edge 心跳（edge 定期上报设备信息时更新心跳）
-	// 优先从 request 的 ClientID 获取
-	var edgeID uint64
-	if clientID := req.ClientID(); clientID > 0 {
-		edgeID = clientID
-	} else {
-		// 如果无法从 ClientID 获取，通过设备查找关联的 edge
-		hostType := model.EdgeDeviceRelationHost
-		edgeDevices, err := fb.repo.GetEdgeDevicesByDeviceID(deviceModel.ID, &hostType)
-		if err == nil && len(edgeDevices) > 0 {
-			edgeID = edgeDevices[0].EdgeID
-		}
-	}
-
-	if edgeID > 0 {
-		fb.updateEdgeHeartbeat(edgeID)
-	} else {
-		log.Debugf("cannot get edgeID from device usage request for heartbeat update")
-	}
+	// 更新 edge 心跳（edge 定期上报设备信息时更新心跳）。
+	fb.updateEdgeHeartbeat(edgeID)
 }
 
 // 上报设备
@@ -63,6 +51,12 @@ func (fb *frontierBound) reportDevice(ctx context.Context, req geminio.Request, 
 		rsp.SetError(err)
 		return
 	}
+	edgeID, err := fb.requireRequestEdge(req, device.EdgeID)
+	if err != nil {
+		rsp.SetError(err)
+		return
+	}
+	device.EdgeID = edgeID
 
 	tx := fb.repo.Begin()
 	committed := false
@@ -258,5 +252,5 @@ func (fb *frontierBound) reportDevice(ctx context.Context, req geminio.Request, 
 	}
 	committed = true
 
-	fb.updateEdgeHeartbeat(req.ClientID())
+	fb.updateEdgeHeartbeat(edgeID)
 }

--- a/pkg/liaison/manager/frontierbound/device_ping.go
+++ b/pkg/liaison/manager/frontierbound/device_ping.go
@@ -3,12 +3,13 @@ package frontierbound
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/jumboframes/armorigo/log"
-	"github.com/singchia/geminio"
 	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
 	"github.com/liaisonio/liaison/pkg/proto"
+	"github.com/singchia/geminio"
 )
 
 // 获取 Edge 发现的设备列表（用于 ping）
@@ -18,10 +19,15 @@ func (fb *frontierBound) getEdgeDiscoveredDevices(ctx context.Context, req gemin
 		rsp.SetError(err)
 		return
 	}
+	edgeID, err := fb.requireRequestEdge(req, request.EdgeID)
+	if err != nil {
+		rsp.SetError(err)
+		return
+	}
 
 	// 通过 EdgeDevice 关系表获取 Edge 发现的设备（类型为 Discovered）
 	discoveredType := model.EdgeDeviceRelationDiscovered
-	edgeDevices, err := fb.repo.GetEdgeDevicesByEdgeID(request.EdgeID, &discoveredType)
+	edgeDevices, err := fb.repo.GetEdgeDevicesByEdgeID(edgeID, &discoveredType)
 	if err != nil {
 		log.Errorf("get edge discovered devices error: %s", err)
 		rsp.SetError(err)
@@ -80,8 +86,25 @@ func (fb *frontierBound) updateDeviceHeartbeat(ctx context.Context, req geminio.
 		rsp.SetError(err)
 		return
 	}
+	edgeID, err := fb.requireRegisteredEdge(req)
+	if err != nil {
+		rsp.SetError(err)
+		return
+	}
 
-	err := fb.repo.UpdateDeviceHeartbeat(uint(request.DeviceID))
+	discoveredType := model.EdgeDeviceRelationDiscovered
+	relation, err := fb.repo.GetEdgeDevice(edgeID, uint(request.DeviceID), discoveredType)
+	if err != nil {
+		log.Errorf("get edge device relation error: %s, edge_id: %d, device_id: %d", err, edgeID, request.DeviceID)
+		rsp.SetError(err)
+		return
+	}
+	if relation == nil {
+		rsp.SetError(fmt.Errorf("device %d is not discovered by edge %d", request.DeviceID, edgeID))
+		return
+	}
+
+	err = fb.repo.UpdateDeviceHeartbeat(uint(request.DeviceID))
 	if err != nil {
 		log.Errorf("update device heartbeat error: %s, device_id: %d", err, request.DeviceID)
 		rsp.SetError(err)

--- a/pkg/liaison/manager/frontierbound/edge.go
+++ b/pkg/liaison/manager/frontierbound/edge.go
@@ -7,4 +7,8 @@ import (
 )
 
 // 上报edge，更改初始化到Running状态
-func (fb *frontierBound) reportEdge(ctx context.Context, req geminio.Request, rsp geminio.Response) {}
+func (fb *frontierBound) reportEdge(ctx context.Context, req geminio.Request, rsp geminio.Response) {
+	if _, err := fb.requireRegisteredEdge(req); err != nil {
+		rsp.SetError(err)
+	}
+}

--- a/pkg/liaison/manager/frontierbound/frontierbound.go
+++ b/pkg/liaison/manager/frontierbound/frontierbound.go
@@ -3,28 +3,46 @@ package frontierbound
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
+	"net/http"
+	"sync"
+	"time"
 
 	"github.com/jumboframes/armorigo/log"
-	"github.com/singchia/frontier/api/dataplane/v1/service"
 	"github.com/liaisonio/liaison/pkg/liaison/config"
 	"github.com/liaisonio/liaison/pkg/liaison/repo"
 	"github.com/liaisonio/liaison/pkg/utils"
+	"github.com/singchia/frontier/api/dataplane/v1/service"
+	"github.com/singchia/geminio"
 )
 
 type FrontierBound interface {
 	EmitScanApplications(ctx context.Context, taskID uint, edgeID uint64, net *Net) error
+	KickEdge(ctx context.Context, edgeID uint64) error
 	Close() error
 }
 
 type frontierBound struct {
 	repo             repo.Repo
 	svc              service.Service
+	edgeConnMu       sync.Mutex
+	edgeConnAddr     map[uint64]string
+	controlPlaneURL  string
+	httpClient       *http.Client
+	registerMu       sync.Mutex
+	cancel           context.CancelFunc
 	trafficCollector interface {
 		RecordTraffic(proxyID, applicationID uint, bytesIn, bytesOut int64)
 	}
 }
+
+const (
+	registrationTimeout         = 10 * time.Second
+	registrationRepairDelay     = 10 * time.Second
+	registrationRefreshInterval = 5 * time.Minute
+)
 
 func NewFrontierBound(conf *config.Configuration, repo repo.Repo, trafficCollector interface {
 	RecordTraffic(proxyID, applicationID uint, bytesIn, bytesOut int64)
@@ -35,6 +53,9 @@ func NewFrontierBound(conf *config.Configuration, repo repo.Repo, trafficCollect
 	}
 	fb := &frontierBound{
 		repo:             repo,
+		edgeConnAddr:     map[uint64]string{},
+		controlPlaneURL:  conf.Frontier.ControlPlaneURL,
+		httpClient:       &http.Client{Timeout: 5 * time.Second},
 		trafficCollector: trafficCollector,
 	}
 
@@ -46,64 +67,78 @@ func NewFrontierBound(conf *config.Configuration, repo repo.Repo, trafficCollect
 		log.Errorf("new service error: %s", err)
 		return nil, err
 	}
-	// 注册frontier回调函数
-	err = svc.RegisterGetEdgeID(context.Background(), fb.getID)
-	if err != nil {
-		log.Errorf("register get edge id error: %s", err)
-		return nil, err
-	}
-	err = svc.RegisterEdgeOnline(context.Background(), fb.online)
-	if err != nil {
-		log.Errorf("register edge online error: %s", err)
-		return nil, err
-	}
-	err = svc.RegisterEdgeOffline(context.Background(), fb.offline)
-	if err != nil {
-		log.Errorf("register edge offline error: %s", err)
-		return nil, err
-	}
-	// 注册liaison函数
-	err = svc.Register(context.Background(), "report_device", fb.reportDevice)
-	if err != nil {
-		log.Errorf("register report device error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "report_device_usage", fb.reportDeviceUsage)
-	if err != nil {
-		log.Errorf("register report device usage error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "report_edge", fb.reportEdge)
-	if err != nil {
-		log.Errorf("register report edge error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "report_task_scan_application", fb.reportTaskScanApplication)
-	if err != nil {
-		log.Errorf("register report task scan application error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "pull_task_scan_application", fb.pullTaskScanApplication)
-	if err != nil {
-		log.Errorf("register pull task scan application error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "get_edge_discovered_devices", fb.getEdgeDiscoveredDevices)
-	if err != nil {
-		log.Errorf("register get edge discovered devices error: %s", err)
-		return nil, err
-	}
-	err = svc.Register(context.Background(), "update_device_heartbeat", fb.updateDeviceHeartbeat)
-	if err != nil {
-		log.Errorf("register update device heartbeat error: %s", err)
-		return nil, err
-	}
-	// 流量统计已移到entry端，不再需要edge端上报
-
 	fb.svc = svc
+	ctx, cancel := context.WithCancel(context.Background())
+	fb.cancel = cancel
+	registerCtx, cancelRegister := context.WithTimeout(context.Background(), registrationTimeout)
+	defer cancelRegister()
+	if err := fb.registerRPCs(registerCtx); err != nil {
+		cancel()
+		_ = svc.Close()
+		return nil, err
+	}
+	go fb.refreshRegistrations(ctx)
 	return fb, nil
 }
 
 func (fb *frontierBound) Close() error {
+	if fb.cancel != nil {
+		fb.cancel()
+	}
 	return fb.svc.Close()
+}
+
+func (fb *frontierBound) refreshRegistrations(ctx context.Context) {
+	timer := time.NewTimer(registrationRepairDelay)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			registerCtx, cancelRegister := context.WithTimeout(ctx, registrationTimeout)
+			err := fb.registerRPCs(registerCtx)
+			cancelRegister()
+			if err != nil {
+				log.Warnf("refresh frontier RPC registrations failed: %s", err)
+			}
+			timer.Reset(registrationRefreshInterval)
+		}
+	}
+}
+
+func (fb *frontierBound) registerRPCs(ctx context.Context) error {
+	fb.registerMu.Lock()
+	defer fb.registerMu.Unlock()
+
+	// 注册 frontier 回调函数。
+	if err := fb.svc.RegisterGetEdgeID(ctx, fb.getID); err != nil {
+		return fmt.Errorf("register get edge id: %w", err)
+	}
+	if err := fb.svc.RegisterEdgeOnline(ctx, fb.online); err != nil {
+		return fmt.Errorf("register edge online: %w", err)
+	}
+	if err := fb.svc.RegisterEdgeOffline(ctx, fb.offline); err != nil {
+		return fmt.Errorf("register edge offline: %w", err)
+	}
+
+	registrations := []struct {
+		name string
+		rpc  func(context.Context, geminio.Request, geminio.Response)
+	}{
+		{name: "report_device", rpc: fb.reportDevice},
+		{name: "report_device_usage", rpc: fb.reportDeviceUsage},
+		{name: "report_edge", rpc: fb.reportEdge},
+		{name: "report_task_scan_application", rpc: fb.reportTaskScanApplication},
+		{name: "pull_task_scan_application", rpc: fb.pullTaskScanApplication},
+		{name: "get_edge_discovered_devices", rpc: fb.getEdgeDiscoveredDevices},
+		{name: "update_device_heartbeat", rpc: fb.updateDeviceHeartbeat},
+	}
+	for _, registration := range registrations {
+		if err := fb.svc.Register(ctx, registration.name, registration.rpc); err != nil {
+			return fmt.Errorf("register %s: %w", registration.name, err)
+		}
+	}
+	return nil
 }

--- a/pkg/liaison/manager/frontierbound/oob.go
+++ b/pkg/liaison/manager/frontierbound/oob.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jumboframes/armorigo/log"
+	"github.com/liaisonio/liaison/pkg/liaison/repo/dao"
 	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
 	"github.com/liaisonio/liaison/pkg/proto"
 )
@@ -31,8 +32,19 @@ func (fb *frontierBound) getID(meta []byte) (uint64, error) {
 // updateEdgeHeartbeat 更新 edge 心跳时间
 func (fb *frontierBound) updateEdgeHeartbeat(edgeID uint64) {
 	log.Debugf("update edge heartbeat: %d", edgeID)
+	edge, err := fb.repo.GetEdge(edgeID)
+	if err != nil {
+		log.Errorf("get edge error while updating heartbeat: %s, edge_id: %d", err, edgeID)
+		return
+	}
+	if edge.Online != model.EdgeOnlineStatusOnline {
+		if err := fb.repo.UpdateEdgeOnlineStatus(edgeID, model.EdgeOnlineStatusOnline); err != nil {
+			log.Errorf("update edge online status error: %s, edge_id: %d", err, edgeID)
+			return
+		}
+	}
 	now := time.Now()
-	err := fb.repo.UpdateEdgeHeartbeatAt(edgeID, now)
+	err = fb.repo.UpdateEdgeHeartbeatAt(edgeID, now)
 	if err != nil {
 		log.Errorf("update edge heartbeat error: %s, edge_id: %d", err, edgeID)
 	}
@@ -44,6 +56,7 @@ func (fb *frontierBound) online(edgeID uint64, meta []byte, addr net.Addr) error
 	if err != nil {
 		return err
 	}
+	fb.rememberEdgeConn(edgeID, addr)
 	// 更新心跳时间
 	fb.updateEdgeHeartbeat(edgeID)
 	return nil
@@ -51,14 +64,77 @@ func (fb *frontierBound) online(edgeID uint64, meta []byte, addr net.Addr) error
 
 func (fb *frontierBound) offline(edgeID uint64, meta []byte, addr net.Addr) error {
 	log.Infof("edge offline: %d, meta: %s, addr: %s", edgeID, string(meta), addr.String())
+	if !fb.shouldApplyEdgeOffline(edgeID, addr) {
+		log.Infof("ignore stale edge offline: %d, addr: %s", edgeID, addr.String())
+		return nil
+	}
 	err := fb.repo.UpdateEdgeOnlineStatus(edgeID, model.EdgeOnlineStatusOffline)
 	if err != nil {
 		return err
 	}
-	// 查询所有edge任务，如果是pending和running状态，则更新为failed
-	err = fb.repo.UpdateTaskError(uint(edgeID), "edge offline")
+	fb.forgetEdgeConn(edgeID, addr)
+	tasks, err := fb.repo.ListTasks(&dao.ListTasksQuery{
+		EdgeID: uint(edgeID),
+		Status: []model.TaskStatus{
+			model.TaskStatusPending,
+			model.TaskStatusRunning,
+		},
+	})
 	if err != nil {
 		return err
 	}
+	for _, task := range tasks {
+		if err := fb.repo.UpdateTaskError(task.ID, "edge offline"); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (fb *frontierBound) rememberEdgeConn(edgeID uint64, addr net.Addr) {
+	if addr == nil {
+		return
+	}
+	fb.edgeConnMu.Lock()
+	defer fb.edgeConnMu.Unlock()
+	if fb.edgeConnAddr == nil {
+		fb.edgeConnAddr = map[uint64]string{}
+	}
+	fb.edgeConnAddr[edgeID] = addr.String()
+}
+
+func (fb *frontierBound) shouldApplyEdgeOffline(edgeID uint64, addr net.Addr) bool {
+	if addr == nil {
+		return true
+	}
+	fb.edgeConnMu.Lock()
+	defer fb.edgeConnMu.Unlock()
+	if fb.edgeConnAddr == nil {
+		return true
+	}
+	currentAddr, ok := fb.edgeConnAddr[edgeID]
+	return !ok || currentAddr == addr.String()
+}
+
+func (fb *frontierBound) forgetEdgeConn(edgeID uint64, addr net.Addr) {
+	if addr == nil {
+		return
+	}
+	fb.edgeConnMu.Lock()
+	defer fb.edgeConnMu.Unlock()
+	if fb.edgeConnAddr == nil {
+		return
+	}
+	if fb.edgeConnAddr[edgeID] == addr.String() {
+		delete(fb.edgeConnAddr, edgeID)
+	}
+}
+
+func (fb *frontierBound) forgetEdge(edgeID uint64) {
+	fb.edgeConnMu.Lock()
+	defer fb.edgeConnMu.Unlock()
+	if fb.edgeConnAddr == nil {
+		return
+	}
+	delete(fb.edgeConnAddr, edgeID)
 }

--- a/pkg/liaison/manager/frontierbound/oob_test.go
+++ b/pkg/liaison/manager/frontierbound/oob_test.go
@@ -1,0 +1,166 @@
+package frontierbound
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/liaisonio/liaison/pkg/liaison/config"
+	"github.com/liaisonio/liaison/pkg/liaison/repo"
+	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
+	"github.com/liaisonio/liaison/pkg/proto"
+)
+
+func newTestRepo(t *testing.T) repo.Repo {
+	t.Helper()
+	conf := &config.Configuration{}
+	conf.Manager.DB = t.TempDir() + "/liaison.db"
+
+	r, err := repo.NewRepo(conf)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	return r
+}
+
+func TestUpdateEdgeHeartbeatMarksRunningEdgeOnline(t *testing.T) {
+	r := newTestRepo(t)
+	edge := &model.Edge{
+		Name:   "edge-1",
+		Status: model.EdgeStatusRunning,
+		Online: model.EdgeOnlineStatusOffline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+
+	fb := &frontierBound{repo: r}
+	fb.updateEdgeHeartbeat(uint64(edge.ID))
+
+	updated, err := r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updated.Online != model.EdgeOnlineStatusOnline {
+		t.Fatalf("online = %d, want %d", updated.Online, model.EdgeOnlineStatusOnline)
+	}
+	if updated.HeartbeatAt.IsZero() {
+		t.Fatalf("heartbeat_at was not updated")
+	}
+}
+
+func TestUpdateEdgeHeartbeatMarksStoppedEdgeOnline(t *testing.T) {
+	r := newTestRepo(t)
+	edge := &model.Edge{
+		Name:   "edge-1",
+		Status: model.EdgeStatusStopped,
+		Online: model.EdgeOnlineStatusOffline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+
+	fb := &frontierBound{repo: r}
+	fb.updateEdgeHeartbeat(uint64(edge.ID))
+
+	updated, err := r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updated.Online != model.EdgeOnlineStatusOnline {
+		t.Fatalf("online = %d, want %d", updated.Online, model.EdgeOnlineStatusOnline)
+	}
+	if updated.HeartbeatAt.IsZero() {
+		t.Fatalf("heartbeat_at was not updated")
+	}
+}
+
+func TestStoppedEdgeCanResolveID(t *testing.T) {
+	r := newTestRepo(t)
+	edge := &model.Edge{
+		Name:   "edge-1",
+		Status: model.EdgeStatusStopped,
+		Online: model.EdgeOnlineStatusOffline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+	accessKey := &model.AccessKey{
+		EdgeID:    edge.ID,
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+	if err := r.CreateAccessKey(accessKey); err != nil {
+		t.Fatalf("create access key: %v", err)
+	}
+
+	meta, err := json.Marshal(proto.Meta{
+		AccessKey: accessKey.AccessKey,
+		SecretKey: accessKey.SecretKey,
+	})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	fb := &frontierBound{repo: r}
+	id, err := fb.getID(meta)
+	if err != nil {
+		t.Fatalf("get id: %v", err)
+	}
+	if id != uint64(edge.ID) {
+		t.Fatalf("edge id = %d, want %d", id, edge.ID)
+	}
+
+	if err := fb.online(id, meta, &net.TCPAddr{}); err != nil {
+		t.Fatalf("online: %v", err)
+	}
+	updated, err := r.GetEdge(id)
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updated.Status != model.EdgeStatusStopped {
+		t.Fatalf("status = %d, want stopped", updated.Status)
+	}
+	if updated.Online != model.EdgeOnlineStatusOnline {
+		t.Fatalf("online = %d, want online", updated.Online)
+	}
+}
+
+func TestOfflineIgnoresStaleConnection(t *testing.T) {
+	r := newTestRepo(t)
+	edge := &model.Edge{
+		Name:   "edge-1",
+		Status: model.EdgeStatusRunning,
+		Online: model.EdgeOnlineStatusOffline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+
+	fb := &frontierBound{repo: r}
+	current := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10002}
+	stale := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 10001}
+	if err := fb.online(uint64(edge.ID), nil, current); err != nil {
+		t.Fatalf("online: %v", err)
+	}
+	if err := fb.offline(uint64(edge.ID), nil, stale); err != nil {
+		t.Fatalf("stale offline: %v", err)
+	}
+	updated, err := r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updated.Online != model.EdgeOnlineStatusOnline {
+		t.Fatalf("stale offline changed online to %d", updated.Online)
+	}
+
+	if err := fb.offline(uint64(edge.ID), nil, current); err != nil {
+		t.Fatalf("current offline: %v", err)
+	}
+	updated, err = r.GetEdge(uint64(edge.ID))
+	if err != nil {
+		t.Fatalf("get edge: %v", err)
+	}
+	if updated.Online != model.EdgeOnlineStatusOffline {
+		t.Fatalf("current offline left online = %d, want offline", updated.Online)
+	}
+}

--- a/pkg/liaison/manager/frontierbound/rpc_auth_test.go
+++ b/pkg/liaison/manager/frontierbound/rpc_auth_test.go
@@ -1,0 +1,222 @@
+package frontierbound
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/liaisonio/liaison/pkg/liaison/repo"
+	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
+	"github.com/liaisonio/liaison/pkg/proto"
+	"gorm.io/gorm"
+)
+
+type fakeRequest struct {
+	clientID uint64
+	data     []byte
+	timeout  time.Duration
+}
+
+func (r *fakeRequest) ID() uint64                       { return 1 }
+func (r *fakeRequest) StreamID() uint64                 { return 0 }
+func (r *fakeRequest) ClientID() uint64                 { return r.clientID }
+func (r *fakeRequest) Method() string                   { return "" }
+func (r *fakeRequest) Timeout() time.Duration           { return r.timeout }
+func (r *fakeRequest) Data() []byte                     { return r.data }
+func (r *fakeRequest) Custom() []byte                   { return nil }
+func (r *fakeRequest) SetTimeout(timeout time.Duration) { r.timeout = timeout }
+func (r *fakeRequest) SetCustom([]byte)                 {}
+func (r *fakeRequest) SetClientID(clientID uint64)      { r.clientID = clientID }
+func (r *fakeRequest) SetStreamID(uint64)               {}
+
+type fakeResponse struct {
+	err      error
+	data     []byte
+	clientID uint64
+	streamID uint64
+	custom   []byte
+}
+
+func (r *fakeResponse) ID() uint64                  { return 1 }
+func (r *fakeResponse) StreamID() uint64            { return r.streamID }
+func (r *fakeResponse) ClientID() uint64            { return r.clientID }
+func (r *fakeResponse) Method() string              { return "" }
+func (r *fakeResponse) Data() []byte                { return r.data }
+func (r *fakeResponse) Error() error                { return r.err }
+func (r *fakeResponse) Custom() []byte              { return r.custom }
+func (r *fakeResponse) SetData(data []byte)         { r.data = data }
+func (r *fakeResponse) SetError(err error)          { r.err = err }
+func (r *fakeResponse) SetCustom(custom []byte)     { r.custom = custom }
+func (r *fakeResponse) SetClientID(clientID uint64) { r.clientID = clientID }
+func (r *fakeResponse) SetStreamID(streamID uint64) { r.streamID = streamID }
+
+func createFrontierboundTestEdge(t *testing.T, r repo.Repo, name string) *model.Edge {
+	t.Helper()
+	edge := &model.Edge{
+		Name:   name,
+		Status: model.EdgeStatusRunning,
+		Online: model.EdgeOnlineStatusOnline,
+	}
+	if err := r.CreateEdge(edge); err != nil {
+		t.Fatalf("create edge: %v", err)
+	}
+	return edge
+}
+
+func newFakeRequest(t *testing.T, edgeID uint64, payload any) *fakeRequest {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return &fakeRequest{clientID: edgeID, data: data}
+}
+
+func TestReportDeviceRejectsDeletedEdge(t *testing.T) {
+	r := newTestRepo(t)
+	defer r.Close()
+	edge := createFrontierboundTestEdge(t, r, "edge-1")
+	if err := r.DeleteEdge(uint64(edge.ID)); err != nil {
+		t.Fatalf("delete edge: %v", err)
+	}
+
+	fb := &frontierBound{repo: r}
+	req := newFakeRequest(t, uint64(edge.ID), proto.Device{
+		Fingerprint: "device-fingerprint",
+		HostName:    "device-1",
+		EdgeID:      uint64(edge.ID),
+	})
+	rsp := &fakeResponse{}
+	fb.reportDevice(context.Background(), req, rsp)
+
+	if rsp.Error() == nil {
+		t.Fatalf("expected deleted edge report to be rejected")
+	}
+	if _, err := r.GetDeviceByFingerprint("device-fingerprint"); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("device should not be created after deleted edge report, err=%v", err)
+	}
+}
+
+func TestReportDeviceBindsHostRelationToConnectionEdge(t *testing.T) {
+	r := newTestRepo(t)
+	defer r.Close()
+	edge := createFrontierboundTestEdge(t, r, "edge-1")
+
+	fb := &frontierBound{repo: r}
+	req := newFakeRequest(t, uint64(edge.ID), proto.Device{
+		Fingerprint: "device-fingerprint",
+		HostName:    "device-1",
+	})
+	rsp := &fakeResponse{}
+	fb.reportDevice(context.Background(), req, rsp)
+	if rsp.Error() != nil {
+		t.Fatalf("report device: %v", rsp.Error())
+	}
+
+	device, err := r.GetDeviceByFingerprint("device-fingerprint")
+	if err != nil {
+		t.Fatalf("get device: %v", err)
+	}
+	relation, err := r.GetEdgeDevice(uint64(edge.ID), device.ID, model.EdgeDeviceRelationHost)
+	if err != nil {
+		t.Fatalf("get edge device relation: %v", err)
+	}
+	if relation == nil {
+		t.Fatalf("expected host relation for connection edge")
+	}
+}
+
+func TestReportDeviceRejectsPayloadEdgeMismatch(t *testing.T) {
+	r := newTestRepo(t)
+	defer r.Close()
+	edge1 := createFrontierboundTestEdge(t, r, "edge-1")
+	edge2 := createFrontierboundTestEdge(t, r, "edge-2")
+
+	fb := &frontierBound{repo: r}
+	req := newFakeRequest(t, uint64(edge1.ID), proto.Device{
+		Fingerprint: "device-fingerprint",
+		HostName:    "device-1",
+		EdgeID:      uint64(edge2.ID),
+	})
+	rsp := &fakeResponse{}
+	fb.reportDevice(context.Background(), req, rsp)
+
+	if rsp.Error() == nil {
+		t.Fatalf("expected mismatched edge id to be rejected")
+	}
+}
+
+func TestPullTaskScanApplicationRejectsPayloadEdgeMismatch(t *testing.T) {
+	r := newTestRepo(t)
+	defer r.Close()
+	edge1 := createFrontierboundTestEdge(t, r, "edge-1")
+	edge2 := createFrontierboundTestEdge(t, r, "edge-2")
+
+	fb := &frontierBound{repo: r}
+	req := newFakeRequest(t, uint64(edge1.ID), proto.PullTaskScanApplicationRequest{
+		EdgeID: uint64(edge2.ID),
+	})
+	rsp := &fakeResponse{}
+	fb.pullTaskScanApplication(context.Background(), req, rsp)
+
+	if rsp.Error() == nil {
+		t.Fatalf("expected mismatched task pull to be rejected")
+	}
+}
+
+func TestUpdateDeviceHeartbeatRequiresDiscoveredRelation(t *testing.T) {
+	r := newTestRepo(t)
+	defer r.Close()
+	edge := createFrontierboundTestEdge(t, r, "edge-1")
+	device := &model.Device{
+		Fingerprint: "device-fingerprint",
+		Name:        "device-1",
+		HostName:    "device-1",
+	}
+	if err := r.CreateDevice(device); err != nil {
+		t.Fatalf("create device: %v", err)
+	}
+
+	fb := &frontierBound{repo: r}
+	req := newFakeRequest(t, uint64(edge.ID), proto.UpdateDeviceHeartbeatRequest{
+		DeviceID: uint64(device.ID),
+	})
+	rsp := &fakeResponse{}
+	fb.updateDeviceHeartbeat(context.Background(), req, rsp)
+
+	if rsp.Error() == nil {
+		t.Fatalf("expected heartbeat for undiscovered device to be rejected")
+	}
+}
+
+func TestKickEdgeCallsFrontierControlPlane(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/edges/42" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	fb := &frontierBound{
+		controlPlaneURL: server.URL,
+		httpClient:      server.Client(),
+		edgeConnAddr:    map[uint64]string{42: "127.0.0.1:12345"},
+	}
+	if err := fb.KickEdge(context.Background(), 42); err != nil {
+		t.Fatalf("kick edge: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected controlplane request")
+	}
+	if _, ok := fb.edgeConnAddr[42]; ok {
+		t.Fatalf("expected remembered edge connection to be cleared")
+	}
+}

--- a/pkg/liaison/manager/frontierbound/task.go
+++ b/pkg/liaison/manager/frontierbound/task.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/jumboframes/armorigo/log"
-	"github.com/singchia/geminio"
 	"github.com/liaisonio/liaison/pkg/liaison/repo/model"
 	"github.com/liaisonio/liaison/pkg/proto"
+	"github.com/singchia/geminio"
 )
 
 type Net struct {
@@ -50,11 +51,20 @@ func (fb *frontierBound) reportTaskScanApplication(ctx context.Context, req gemi
 		rsp.SetError(err)
 		return
 	}
+	edgeID, err := fb.requireRegisteredEdge(req)
+	if err != nil {
+		rsp.SetError(err)
+		return
+	}
 
 	// 获取任务
 	mtask, err := fb.repo.GetTask(task.TaskID)
 	if err != nil {
 		rsp.SetError(err)
+		return
+	}
+	if mtask.EdgeID != edgeID {
+		rsp.SetError(fmt.Errorf("task %d does not belong to edge %d", task.TaskID, edgeID))
 		return
 	}
 	if mtask.TaskStatus == model.TaskStatusFailed {
@@ -116,9 +126,14 @@ func (fb *frontierBound) pullTaskScanApplication(ctx context.Context, req gemini
 		rsp.SetError(err)
 		return
 	}
+	edgeID, err := fb.requireRequestEdge(req, request.EdgeID)
+	if err != nil {
+		rsp.SetError(err)
+		return
+	}
 
 	// 获取任务
-	task, err := fb.repo.GetTaskByEdgeID(request.EdgeID)
+	task, err := fb.repo.GetTaskByEdgeID(edgeID)
 	if err != nil {
 		rsp.SetError(err)
 		return

--- a/pkg/liaison/manager/web/web.go
+++ b/pkg/liaison/manager/web/web.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,15 +39,29 @@ type web struct {
 }
 
 func NewWebServer(conf *config.Configuration, controlPlane controlplane.ControlPlane, iamService *iam.IAMService) (Web, error) {
+	ln, err := NewListener(conf)
+	if err != nil {
+		return nil, err
+	}
+	web, err := NewWebServerWithListener(conf, controlPlane, iamService, ln)
+	if err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	return web, nil
+}
+
+func NewListener(conf *config.Configuration) (net.Listener, error) {
+	return utils.Listen(&conf.Manager.Listen)
+}
+
+func NewWebServerWithListener(conf *config.Configuration, controlPlane controlplane.ControlPlane, iamService *iam.IAMService, ln net.Listener) (Web, error) {
+	if ln == nil {
+		return nil, errors.New("web listener is nil")
+	}
 	web := &web{
 		controlPlane: controlPlane,
 		iamService:   iamService,
-	}
-
-	listen := &conf.Manager.Listen
-	ln, err := utils.Listen(listen)
-	if err != nil {
-		return nil, err
 	}
 	// 创建认证中间件
 	authMiddleware := iam.AuthMiddleware(web.iamService)
@@ -69,8 +85,7 @@ func NewWebServer(conf *config.Configuration, controlPlane controlplane.ControlP
 	srv.HandleFunc("/api/v1/proxies/{id}/firewall", web.handleFirewallHTTP)
 
 	// 文件服务
-	err = web.serveFiles(conf, srv)
-	if err != nil {
+	if err := web.serveFiles(conf, srv); err != nil {
 		return nil, err
 	}
 

--- a/pkg/liaison/repo/dao/dao.go
+++ b/pkg/liaison/repo/dao/dao.go
@@ -43,6 +43,7 @@ type Dao interface {
 	// AccessKey 相关方法
 	CreateAccessKey(accessKey *model.AccessKey) error
 	GetAccessKeyByID(id uint) (*model.AccessKey, error)
+	DeleteAccessKeysByEdgeID(edgeID uint64) error
 
 	// Device 相关方法
 	CreateDevice(device *model.Device) error

--- a/pkg/liaison/repo/dao/dao_access_key.go
+++ b/pkg/liaison/repo/dao/dao_access_key.go
@@ -13,3 +13,7 @@ func (d *dao) GetAccessKeyByID(id uint) (*model.AccessKey, error) {
 	}
 	return &accessKey, nil
 }
+
+func (d *dao) DeleteAccessKeysByEdgeID(edgeID uint64) error {
+	return d.getDB().Where("edge_id = ?", edgeID).Delete(&model.AccessKey{}).Error
+}

--- a/pkg/liaison/repo/dao/dao_edge.go
+++ b/pkg/liaison/repo/dao/dao_edge.go
@@ -105,6 +105,9 @@ func (d *dao) UpdateEdge(edge *model.Edge) error {
 	if edge.Status != 0 {
 		updates["status"] = edge.Status
 	}
+	if edge.Online != 0 {
+		updates["online"] = edge.Online
+	}
 	if len(updates) > 0 {
 		if err := d.getDB().Model(&model.Edge{}).Where("id = ?", edge.ID).Updates(updates).Error; err != nil {
 			return err

--- a/web/src/pages/App/index.tsx
+++ b/web/src/pages/App/index.tsx
@@ -1,3 +1,25 @@
+import { CreateButton, DeleteLink } from '@/components/TableButtons';
+import { useI18n } from '@/i18n';
+import {
+  createApplication,
+  createProxy,
+  deleteApplication,
+  getApplicationList,
+  getDeviceList,
+  getEdgeList,
+  updateApplication,
+} from '@/services/api';
+import { executeAction, tableRequest } from '@/utils/request';
+import {
+  buildSearchParams,
+  defaultPagination,
+  defaultSearch,
+} from '@/utils/tableConfig';
+import {
+  ApiOutlined,
+  CheckCircleOutlined,
+  LinkOutlined,
+} from '@ant-design/icons';
 import {
   ActionType,
   ModalForm,
@@ -8,23 +30,8 @@ import {
   ProFormText,
   ProTable,
 } from '@ant-design/pro-components';
-import { Space, Tag, Typography, Select, Form, Alert } from 'antd';
-import { CheckCircleOutlined } from '@ant-design/icons';
-import { LinkOutlined, ApiOutlined } from '@ant-design/icons';
+import { Alert, Form, Space, Tag, Typography } from 'antd';
 import { useRef, useState } from 'react';
-import {
-  getApplicationList,
-  createApplication,
-  updateApplication,
-  deleteApplication,
-  getEdgeList,
-  createProxy,
-  getDeviceList,
-} from '@/services/api';
-import { executeAction, tableRequest } from '@/utils/request';
-import { CreateButton, DeleteLink } from '@/components/TableButtons';
-import { defaultPagination, defaultSearch, buildSearchParams } from '@/utils/tableConfig';
-import { useI18n } from '@/i18n';
 
 const { Text } = Typography;
 
@@ -37,8 +44,12 @@ const AppPage: React.FC = () => {
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [proxyModalVisible, setProxyModalVisible] = useState(false);
   const [currentRow, setCurrentRow] = useState<API.Application>();
-  const [selectedApplicationType, setSelectedApplicationType] = useState<string | undefined>();
-  const [deviceOptions, setDeviceOptions] = useState<{ label: string; value: string }[]>([]);
+  const [selectedApplicationType, setSelectedApplicationType] = useState<
+    string | undefined
+  >();
+  const [deviceOptions, setDeviceOptions] = useState<
+    { label: string; value: string }[]
+  >([]);
 
   const reload = () => actionRef.current?.reload();
 
@@ -106,7 +117,7 @@ const AppPage: React.FC = () => {
     if (!currentRow?.id) return false;
     const createPort = values.port || undefined;
     let createdProxy: API.Proxy | null = null;
-    
+
     const result = await executeAction(
       () =>
         createProxy({
@@ -126,12 +137,12 @@ const AppPage: React.FC = () => {
         },
       },
     );
-    
+
     // 如果创建时端口为空，创建后获取动态分配的端口
     // 端口已经在响应中返回，刷新列表即可显示动态分配的端口
     setProxyModalVisible(false);
     reload();
-    
+
     return result;
   };
 
@@ -204,8 +215,10 @@ const AppPage: React.FC = () => {
         showSearch: true,
         allowClear: true,
         options: deviceOptions,
-        filterOption: (input: string, option?: { label: string; value: string }) =>
-          (option?.label ?? '').toLowerCase().includes(input.toLowerCase()),
+        filterOption: (
+          input: string,
+          option?: { label: string; value: string },
+        ) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase()),
         onFocus: loadDeviceOptions,
         onChange: (val: string) => {
           // 使用 formRef 获取表单实例并设置值
@@ -252,20 +265,28 @@ const AppPage: React.FC = () => {
       align: 'center',
       render: (_, record) => (
         <Space>
-          <a onClick={() => {
-            setCurrentRow(record);
-            setProxyModalVisible(true);
-          }}>
+          <a
+            onClick={() => {
+              setCurrentRow(record);
+              setProxyModalVisible(true);
+            }}
+          >
             {tr('创建访问', 'Create Entry')}
           </a>
-          <a onClick={() => {
-            setCurrentRow(record);
-            setEditModalVisible(true);
-          }}>
+          <a
+            onClick={() => {
+              setCurrentRow(record);
+              setEditModalVisible(true);
+            }}
+          >
             {tr('编辑', 'Edit')}
           </a>
           <DeleteLink
             title={tr('确定要删除这个应用吗？', 'Delete this application?')}
+            description={tr(
+              '将连带删除该应用下的所有访问和访问规则，历史流量记录会保留',
+              'All entries and access rules under this application will be removed. Traffic history will be retained',
+            )}
             onConfirm={() => handleDelete(record.id)}
           />
         </Space>
@@ -277,34 +298,43 @@ const AppPage: React.FC = () => {
     <PageContainer>
       <div className="table-search-wrapper">
         <ProTable<API.Application>
-        headerTitle={tr('应用列表', 'Applications')}
-        actionRef={actionRef}
-        formRef={formRef}
-        rowKey="id"
-        columns={columns}
-        request={async (params) => {
-          console.log('ProTable request params:', params);
-          const searchParams = buildSearchParams<API.ApplicationListParams>(params, ['name', 'device_name', 'application_type']);
-          console.log('buildSearchParams result:', searchParams);
-          return tableRequest(() => getApplicationList(searchParams), 'applications');
-        }}
-        onSubmit={(values) => {
-          console.log('ProTable onSubmit:', values);
-          // 触发表格刷新，此时会使用表单值
-          actionRef.current?.reload();
-        }}
-        toolBarRender={() => [
-          <CreateButton key="create" onClick={() => setCreateModalVisible(true)}>
-            {tr('新建应用', 'New Application')}
-          </CreateButton>,
-        ]}
-        pagination={defaultPagination}
-        search={{
-          ...defaultSearch,
-          labelWidth: 'auto',
-        }}
-        scroll={{ x: 'max-content' }}
-      />
+          headerTitle={tr('应用列表', 'Applications')}
+          actionRef={actionRef}
+          formRef={formRef}
+          rowKey="id"
+          columns={columns}
+          request={async (params) => {
+            console.log('ProTable request params:', params);
+            const searchParams = buildSearchParams<API.ApplicationListParams>(
+              params,
+              ['name', 'device_name', 'application_type'],
+            );
+            console.log('buildSearchParams result:', searchParams);
+            return tableRequest(
+              () => getApplicationList(searchParams),
+              'applications',
+            );
+          }}
+          onSubmit={(values) => {
+            console.log('ProTable onSubmit:', values);
+            // 触发表格刷新，此时会使用表单值
+            actionRef.current?.reload();
+          }}
+          toolBarRender={() => [
+            <CreateButton
+              key="create"
+              onClick={() => setCreateModalVisible(true)}
+            >
+              {tr('新建应用', 'New Application')}
+            </CreateButton>,
+          ]}
+          pagination={defaultPagination}
+          search={{
+            ...defaultSearch,
+            labelWidth: 'auto',
+          }}
+          scroll={{ x: 'max-content' }}
+        />
       </div>
 
       <ModalForm
@@ -325,12 +355,20 @@ const AppPage: React.FC = () => {
           name="name"
           label={tr('应用名称', 'Application Name')}
           placeholder={tr('请输入应用名称', 'Please input application name')}
-          rules={[{ required: true, message: tr('请输入应用名称', 'Please input application name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入应用名称', 'Please input application name'),
+            },
+          ]}
         />
         <ProFormSelect
           name="application_type"
           label={tr('应用类型', 'Application Type')}
-          placeholder={tr('请选择应用类型（不填默认为TCP）', 'Please select application type (default TCP)')}
+          placeholder={tr(
+            '请选择应用类型（不填默认为TCP）',
+            'Please select application type (default TCP)',
+          )}
           options={[
             { label: 'HTTP', value: 'http' },
             { label: 'TCP', value: 'tcp' },
@@ -364,10 +402,39 @@ const AppPage: React.FC = () => {
         />
         {selectedApplicationType === 'http' && (
           <Alert
-            message={<span style={{ fontSize: '11px', lineHeight: '16px', marginBottom: 0, display: 'block' }}>{tr('将开启 HTTPS', 'HTTPS will be enabled')}</span>}
-            description={<span style={{ fontSize: '10px', lineHeight: '14px', marginTop: 0, display: 'block' }}>{tr('HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书', 'HTTP applications will be exposed over HTTPS with configured TLS certificates')}</span>}
+            message={
+              <span
+                style={{
+                  fontSize: '11px',
+                  lineHeight: '16px',
+                  marginBottom: 0,
+                  display: 'block',
+                }}
+              >
+                {tr('将开启 HTTPS', 'HTTPS will be enabled')}
+              </span>
+            }
+            description={
+              <span
+                style={{
+                  fontSize: '10px',
+                  lineHeight: '14px',
+                  marginTop: 0,
+                  display: 'block',
+                }}
+              >
+                {tr(
+                  'HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书',
+                  'HTTP applications will be exposed over HTTPS with configured TLS certificates',
+                )}
+              </span>
+            }
             type="info"
-            icon={<CheckCircleOutlined style={{ color: '#52c41a', fontSize: '14px' }} />}
+            icon={
+              <CheckCircleOutlined
+                style={{ color: '#52c41a', fontSize: '14px' }}
+              />
+            }
             style={{ marginBottom: 16, padding: '8px 12px' }}
             messageStyle={{ marginBottom: 0 }}
             descriptionStyle={{ marginTop: 0 }}
@@ -376,8 +443,16 @@ const AppPage: React.FC = () => {
         <ProFormText
           name="ip"
           label={tr('IP 地址', 'IP Address')}
-          placeholder={tr('请输入应用 IP 地址，如 192.168.1.100', 'Please input application IP, e.g. 192.168.1.100')}
-          rules={[{ required: true, message: tr('请输入 IP 地址', 'Please input IP address') }]}
+          placeholder={tr(
+            '请输入应用 IP 地址，如 192.168.1.100',
+            'Please input application IP, e.g. 192.168.1.100',
+          )}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入 IP 地址', 'Please input IP address'),
+            },
+          ]}
         />
         <ProFormDigit
           name="port"
@@ -386,14 +461,31 @@ const AppPage: React.FC = () => {
           min={1}
           max={65535}
           rules={[
-            { required: true, message: tr('请输入端口号', 'Please input port') },
+            {
+              required: true,
+              message: tr('请输入端口号', 'Please input port'),
+            },
             {
               validator: (_: any, value: number) => {
                 if (!value || value === 0) {
-                  return Promise.reject(new Error(tr('端口号不能为0，请输入1-65535之间的端口号', 'Port cannot be 0, valid range is 1-65535')));
+                  return Promise.reject(
+                    new Error(
+                      tr(
+                        '端口号不能为0，请输入1-65535之间的端口号',
+                        'Port cannot be 0, valid range is 1-65535',
+                      ),
+                    ),
+                  );
                 }
                 if (value < 1 || value > 65535) {
-                  return Promise.reject(new Error(tr('端口号必须在1-65535之间', 'Port must be between 1 and 65535')));
+                  return Promise.reject(
+                    new Error(
+                      tr(
+                        '端口号必须在1-65535之间',
+                        'Port must be between 1 and 65535',
+                      ),
+                    ),
+                  );
                 }
                 return Promise.resolve();
               },
@@ -404,7 +496,12 @@ const AppPage: React.FC = () => {
           name="edge_id"
           label={tr('连接器', 'Edge')}
           placeholder={tr('请选择连接器', 'Please select edge')}
-          rules={[{ required: true, message: tr('请选择连接器', 'Please select edge') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请选择连接器', 'Please select edge'),
+            },
+          ]}
           request={async () => {
             try {
               const res = await getEdgeList({ page_size: 100 });
@@ -434,7 +531,12 @@ const AppPage: React.FC = () => {
           name="name"
           label={tr('应用名称', 'Application Name')}
           placeholder={tr('请输入应用名称', 'Please input application name')}
-          rules={[{ required: true, message: tr('请输入应用名称', 'Please input application name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入应用名称', 'Please input application name'),
+            },
+          ]}
         />
       </ModalForm>
 
@@ -451,14 +553,48 @@ const AppPage: React.FC = () => {
           label={tr('访问名称', 'Entry Name')}
           placeholder={tr('请输入访问名称', 'Please input entry name')}
           initialValue={currentRow?.name}
-          rules={[{ required: true, message: tr('请输入访问名称', 'Please input entry name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入访问名称', 'Please input entry name'),
+            },
+          ]}
         />
         {currentRow?.application_type === 'http' && (
           <Alert
-            message={<span style={{ fontSize: '11px', lineHeight: '16px', marginBottom: 0, display: 'block' }}>{tr('将开启 HTTPS', 'HTTPS will be enabled')}</span>}
-            description={<span style={{ fontSize: '10px', lineHeight: '14px', marginTop: 0, display: 'block' }}>{tr('HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书', 'HTTP applications will be exposed over HTTPS with configured TLS certificates')}</span>}
+            message={
+              <span
+                style={{
+                  fontSize: '11px',
+                  lineHeight: '16px',
+                  marginBottom: 0,
+                  display: 'block',
+                }}
+              >
+                {tr('将开启 HTTPS', 'HTTPS will be enabled')}
+              </span>
+            }
+            description={
+              <span
+                style={{
+                  fontSize: '10px',
+                  lineHeight: '14px',
+                  marginTop: 0,
+                  display: 'block',
+                }}
+              >
+                {tr(
+                  'HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书',
+                  'HTTP applications will be exposed over HTTPS with configured TLS certificates',
+                )}
+              </span>
+            }
             type="info"
-            icon={<CheckCircleOutlined style={{ color: '#52c41a', fontSize: '14px' }} />}
+            icon={
+              <CheckCircleOutlined
+                style={{ color: '#52c41a', fontSize: '14px' }}
+              />
+            }
             style={{ marginBottom: 16, padding: '8px 12px' }}
             messageStyle={{ marginBottom: 0 }}
             descriptionStyle={{ marginTop: 0 }}
@@ -470,7 +606,10 @@ const AppPage: React.FC = () => {
           placeholder={tr('留空自动分配', 'Leave empty for auto allocation')}
           min={1}
           max={65535}
-          extra={tr('映射到公网的端口号，留空则自动分配', 'Mapped public port, empty means auto allocation')}
+          extra={tr(
+            '映射到公网的端口号，留空则自动分配',
+            'Mapped public port, empty means auto allocation',
+          )}
         />
         <ProFormText
           name="description"

--- a/web/src/pages/Connector/index.tsx
+++ b/web/src/pages/Connector/index.tsx
@@ -1,53 +1,57 @@
+import { CreateButton, DeleteLink } from '@/components/TableButtons';
+import { useI18n } from '@/i18n';
+import {
+  createApplication,
+  createEdge,
+  createEdgeScanTask,
+  deleteEdge,
+  getDeviceList,
+  getEdgeList,
+  getEdgeScanTask,
+  updateEdge,
+} from '@/services/api';
+import { copyToClipboard } from '@/utils/format';
+import { executeAction, tableRequest } from '@/utils/request';
+import {
+  buildSearchParams,
+  defaultPagination,
+  defaultSearch,
+} from '@/utils/tableConfig';
+import {
+  CheckCircleOutlined,
+  CopyOutlined,
+  LoadingOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
 import {
   ActionType,
+  ModalForm,
   PageContainer,
   ProColumns,
-  ProTable,
-  StepsForm,
   ProFormText,
   ProFormTextArea,
-  ProFormSelect,
-  ModalForm,
+  ProTable,
+  StepsForm,
 } from '@ant-design/pro-components';
+import { history } from '@umijs/max';
 import {
+  Alert,
+  App,
   Badge,
   Button,
   Drawer,
   List,
-  App,
   Modal,
+  Result,
+  Select,
   Space,
+  Spin,
+  Switch,
+  Tabs,
   Tag,
   Typography,
-  Spin,
-  Result,
-  Alert,
-  Select,
-  Tabs,
 } from 'antd';
-import {
-  CopyOutlined,
-  CheckCircleOutlined,
-  LoadingOutlined,
-  ReloadOutlined,
-} from '@ant-design/icons';
 import { useRef, useState } from 'react';
-import { history } from '@umijs/max';
-import {
-  getEdgeList,
-  createEdge,
-  updateEdge,
-  deleteEdge,
-  getEdgeScanTask,
-  createEdgeScanTask,
-  createApplication,
-  getDeviceList,
-} from '@/services/api';
-import { executeAction, tableRequest } from '@/utils/request';
-import { CreateButton, DeleteLink } from '@/components/TableButtons';
-import { defaultPagination, defaultSearch, buildSearchParams } from '@/utils/tableConfig';
-import { copyToClipboard } from '@/utils/format';
-import { useI18n } from '@/i18n';
 
 const { Text, Paragraph } = Typography;
 
@@ -63,7 +67,9 @@ const ConnectorPage: React.FC = () => {
   const [accessKeys, setAccessKeys] = useState<API.EdgeCreateResult>();
   const [scanTask, setScanTask] = useState<API.EdgeScanApplicationTask>();
   const [scanning, setScanning] = useState(false);
-  const [deviceOptions, setDeviceOptions] = useState<{ label: string; value: string }[]>([]);
+  const [deviceOptions, setDeviceOptions] = useState<
+    { label: string; value: string }[]
+  >([]);
   const [installOS, setInstallOS] = useState<'windows' | 'other'>('other');
 
   const reload = () => actionRef.current?.reload();
@@ -103,7 +109,6 @@ const ConnectorPage: React.FC = () => {
         updateEdge(currentRow.id, {
           name: values.name,
           description: values.description,
-          status: values.status,
         }),
       {
         successMessage: tr('更新成功', 'Updated successfully'),
@@ -116,9 +121,36 @@ const ConnectorPage: React.FC = () => {
     );
   };
 
+  const handleRuntimeToggle = async (record: API.Edge, checked: boolean) => {
+    await executeAction(
+      () => updateEdge(record.id, { status: checked ? 1 : 2 }),
+      {
+        successMessage: checked
+          ? tr('连接器已启用', 'Edge enabled')
+          : tr('连接器已禁用', 'Edge disabled'),
+        errorMessage: tr('操作失败', 'Operation failed'),
+        onSuccess: reload,
+      },
+    );
+  };
+
   const handleDiscoverApps = async (edge: API.Edge) => {
+    if (edge.status !== 1) {
+      message.warning(
+        tr(
+          '连接器已禁用，无法扫描应用',
+          'Edge is disabled, cannot scan applications',
+        ),
+      );
+      return;
+    }
     if (edge.online !== 1) {
-      message.warning(tr('连接器不在线，无法扫描应用', 'Edge is offline, cannot scan applications'));
+      message.warning(
+        tr(
+          '连接器不在线，无法扫描应用',
+          'Edge is offline, cannot scan applications',
+        ),
+      );
       return;
     }
 
@@ -147,16 +179,21 @@ const ConnectorPage: React.FC = () => {
       }
 
       // 没有任务或任务状态允许创建新任务，则创建新的扫描任务
-      const createRes = await createEdgeScanTask({ 
+      const createRes = await createEdgeScanTask({
         edge_id: edge.id,
         protocol: 'tcp',
       });
       if (createRes.code !== 200) {
-        message.error(createRes.message || tr('创建扫描任务失败', 'Failed to create scan task'));
+        message.error(
+          createRes.message ||
+            tr('创建扫描任务失败', 'Failed to create scan task'),
+        );
         setScanning(false);
         return;
       }
-      await new Promise<void>(resolve => { setTimeout(resolve, 1000); });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1000);
+      });
       const res = await getEdgeScanTask(edge.id);
       if (res.code === 200 && res.data) {
         setScanTask(res.data);
@@ -175,16 +212,21 @@ const ConnectorPage: React.FC = () => {
     setScanTask(undefined);
 
     try {
-      const createRes = await createEdgeScanTask({ 
+      const createRes = await createEdgeScanTask({
         edge_id: currentRow.id,
         protocol: 'tcp',
       });
       if (createRes.code !== 200) {
-        message.error(createRes.message || tr('创建扫描任务失败', 'Failed to create scan task'));
+        message.error(
+          createRes.message ||
+            tr('创建扫描任务失败', 'Failed to create scan task'),
+        );
         setScanning(false);
         return;
       }
-      await new Promise<void>(resolve => { setTimeout(resolve, 1000); });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1000);
+      });
       const res = await getEdgeScanTask(currentRow.id);
       if (res.code === 200 && res.data) {
         setScanTask(res.data);
@@ -218,19 +260,21 @@ const ConnectorPage: React.FC = () => {
     const ip = parts[0];
     const port = parseInt(parts[1], 10);
     // 如果后端已经提供了类型，使用后端的类型；否则根据端口推断
-    const appType = parts[2] || (() => {
-      const portToType: Record<number, string> = {
-        22: 'ssh',
-        80: 'http',
-        443: 'http',
-        3389: 'rdp',
-        3306: 'mysql',
-        5432: 'postgresql',
-        6379: 'redis',
-        27017: 'mongodb',
-      };
-      return portToType[port] || 'tcp';
-    })();
+    const appType =
+      parts[2] ||
+      (() => {
+        const portToType: Record<number, string> = {
+          22: 'ssh',
+          80: 'http',
+          443: 'http',
+          3389: 'rdp',
+          3306: 'mysql',
+          5432: 'postgresql',
+          6379: 'redis',
+          27017: 'mongodb',
+        };
+        return portToType[port] || 'tcp';
+      })();
 
     // 显示确认对话框
     const handleAddOnly = async () => {
@@ -263,7 +307,16 @@ const ConnectorPage: React.FC = () => {
       title: tr('添加应用', 'Add Application'),
       content: (
         <div>
-          <div style={{ marginBottom: 8 }}>{tr('确定要添加应用', 'Add application')} <strong>{ip}:{port}</strong> {tr('吗？是否同时创建访问？', 'and create an entry at the same time?')}</div>
+          <div style={{ marginBottom: 8 }}>
+            {tr('确定要添加应用', 'Add application')}{' '}
+            <strong>
+              {ip}:{port}
+            </strong>{' '}
+            {tr(
+              '吗？是否同时创建访问？',
+              'and create an entry at the same time?',
+            )}
+          </div>
         </div>
       ),
       width: 450,
@@ -275,10 +328,12 @@ const ConnectorPage: React.FC = () => {
       okButtonProps: { style: { marginRight: 80 } },
       footer: (_, { OkBtn }) => (
         <>
-          <Button onClick={async () => {
-            modalInstance.destroy();
-            await handleAddOnly();
-          }}>
+          <Button
+            onClick={async () => {
+              modalInstance.destroy();
+              await handleAddOnly();
+            }}
+          >
             {tr('只添加应用', 'Add Only')}
           </Button>
           <OkBtn />
@@ -302,13 +357,19 @@ const ConnectorPage: React.FC = () => {
               if (scanTask) {
                 setScanTask({
                   ...scanTask,
-                  applications: scanTask.applications.filter((a) => a !== appStr),
+                  applications: scanTask.applications.filter(
+                    (a) => a !== appStr,
+                  ),
                 });
               }
               // 跳转到访问页面，传递应用ID、名称和autoCreate参数
               if (data?.id) {
-                const appName = encodeURIComponent(data.name || `App-${ip}:${port}`);
-                history.push(`/proxy?application_id=${data.id}&application_name=${appName}&autoCreate=true`);
+                const appName = encodeURIComponent(
+                  data.name || `App-${ip}:${port}`,
+                );
+                history.push(
+                  `/proxy?application_id=${data.id}&application_name=${appName}&autoCreate=true`,
+                );
               } else {
                 history.push('/proxy?autoCreate=true');
               }
@@ -347,7 +408,10 @@ const ConnectorPage: React.FC = () => {
             showSearch
             allowClear
             options={deviceOptions}
-            filterOption={(input: string, option?: { label: string; value: string }) =>
+            filterOption={(
+              input: string,
+              option?: { label: string; value: string },
+            ) =>
               (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
             }
             onFocus={loadDeviceOptions}
@@ -378,19 +442,24 @@ const ConnectorPage: React.FC = () => {
       render: (_, record) => (
         <Badge
           status={record.online === 1 ? 'success' : 'default'}
-          text={record.online === 1 ? tr('在线', 'Online') : tr('离线', 'Offline')}
+          text={
+            record.online === 1 ? tr('在线', 'Online') : tr('离线', 'Offline')
+          }
         />
       ),
     },
     {
       title: tr('运行状态', 'Runtime Status'),
       dataIndex: 'status',
-      width: 100,
+      width: 130,
       search: false,
       render: (_, record) => (
-        <Tag color={record.status === 1 ? 'green' : 'default'}>
-          {record.status === 1 ? tr('运行中', 'Running') : tr('已停止', 'Stopped')}
-        </Tag>
+        <Switch
+          checked={record.status === 1}
+          checkedChildren={tr('运行', 'On')}
+          unCheckedChildren={tr('停止', 'Off')}
+          onChange={(checked) => handleRuntimeToggle(record, checked)}
+        />
       ),
     },
     {
@@ -419,15 +488,20 @@ const ConnectorPage: React.FC = () => {
           <a onClick={() => handleDiscoverApps(record)}>
             {tr('扫描应用', 'Scan Apps')}
           </a>
-          <a onClick={() => {
-            setCurrentRow(record);
-            setEditModalVisible(true);
-          }}>
+          <a
+            onClick={() => {
+              setCurrentRow(record);
+              setEditModalVisible(true);
+            }}
+          >
             {tr('编辑', 'Edit')}
           </a>
           <DeleteLink
             title={tr('确定要删除这个连接器吗？', 'Delete this edge?')}
-            description={tr('删除后，该连接器关联的所有应用和访问将失效', 'Related applications and entries will become invalid after deletion')}
+            description={tr(
+              '将连带删除该连接器承载的应用、访问、访问密钥和关系，历史流量与任务记录会保留',
+              'Applications, entries, access keys, and relations on this edge will be removed. Traffic and task history will be retained',
+            )}
             onConfirm={() => handleDelete(record.id)}
           />
         </Space>
@@ -439,34 +513,37 @@ const ConnectorPage: React.FC = () => {
     <PageContainer>
       <div className="table-search-wrapper">
         <ProTable<API.Edge>
-        headerTitle={tr('连接器列表', 'Edges')}
-        actionRef={actionRef}
-        formRef={formRef}
-        rowKey="id"
-        columns={columns}
-        request={async (params) => {
-          console.log('ProTable request params:', params);
-          const searchParams = buildSearchParams<API.EdgeListParams>(params, ['name', 'device_name']);
-          console.log('buildSearchParams result:', searchParams);
-          return tableRequest(() => getEdgeList(searchParams), 'edges');
-        }}
-        onSubmit={(values) => {
-          console.log('ProTable onSubmit:', values);
-          // 触发表格刷新，此时会使用表单值
-          actionRef.current?.reload();
-        }}
-        toolBarRender={() => [
-          <CreateButton key="create" onClick={handleOpenCreateModal}>
-            {tr('新建连接器', 'New Edge')}
-          </CreateButton>,
-        ]}
-        pagination={defaultPagination}
-        search={{
-          ...defaultSearch,
-          labelWidth: 'auto',
-        }}
-        scroll={{ x: 'max-content' }}
-      />
+          headerTitle={tr('连接器列表', 'Edges')}
+          actionRef={actionRef}
+          formRef={formRef}
+          rowKey="id"
+          columns={columns}
+          request={async (params) => {
+            console.log('ProTable request params:', params);
+            const searchParams = buildSearchParams<API.EdgeListParams>(params, [
+              'name',
+              'device_name',
+            ]);
+            console.log('buildSearchParams result:', searchParams);
+            return tableRequest(() => getEdgeList(searchParams), 'edges');
+          }}
+          onSubmit={(values) => {
+            console.log('ProTable onSubmit:', values);
+            // 触发表格刷新，此时会使用表单值
+            actionRef.current?.reload();
+          }}
+          toolBarRender={() => [
+            <CreateButton key="create" onClick={handleOpenCreateModal}>
+              {tr('新建连接器', 'New Edge')}
+            </CreateButton>,
+          ]}
+          pagination={defaultPagination}
+          search={{
+            ...defaultSearch,
+            labelWidth: 'auto',
+          }}
+          scroll={{ x: 'max-content' }}
+        />
       </div>
 
       <StepsForm
@@ -497,7 +574,10 @@ const ConnectorPage: React.FC = () => {
             if (props.step === 2) {
               return dom.map((item: any) => {
                 if (item.key === 'submit') {
-                  return { ...item, props: { ...item.props, children: tr('完成', 'Done') } };
+                  return {
+                    ...item,
+                    props: { ...item.props, children: tr('完成', 'Done') },
+                  };
                 }
                 return item;
               });
@@ -521,7 +601,9 @@ const ConnectorPage: React.FC = () => {
               });
               if (res.code === 200 && res.data) {
                 setAccessKeys(res.data);
-                message.success(tr('连接器创建成功', 'Edge created successfully'));
+                message.success(
+                  tr('连接器创建成功', 'Edge created successfully'),
+                );
                 return true;
               }
               message.error(res.message || tr('创建失败', 'Create failed'));
@@ -536,13 +618,24 @@ const ConnectorPage: React.FC = () => {
             name="name"
             label={tr('连接器名称', 'Edge Name')}
             placeholder={tr('请输入连接器名称', 'Please input edge name')}
-            rules={[{ required: true, message: tr('请输入连接器名称', 'Please input edge name') }]}
-            extra={tr('名称用于标识这个连接器，建议使用有意义的名称', 'Use a meaningful name to identify this edge')}
+            rules={[
+              {
+                required: true,
+                message: tr('请输入连接器名称', 'Please input edge name'),
+              },
+            ]}
+            extra={tr(
+              '名称用于标识这个连接器，建议使用有意义的名称',
+              'Use a meaningful name to identify this edge',
+            )}
           />
           <ProFormTextArea
             name="description"
             label={tr('描述', 'Description')}
-            placeholder={tr('请输入连接器描述（可选）', 'Please input edge description (optional)')}
+            placeholder={tr(
+              '请输入连接器描述（可选）',
+              'Please input edge description (optional)',
+            )}
           />
         </StepsForm.StepForm>
 
@@ -554,7 +647,10 @@ const ConnectorPage: React.FC = () => {
           {accessKeys ? (
             <>
               <Alert
-                message={tr('连接器已创建，请复制下面的安装命令在目标设备上执行', 'Edge created. Copy and run the command on target device')}
+                message={tr(
+                  '连接器已创建，请复制下面的安装命令在目标设备上执行',
+                  'Edge created. Copy and run the command on target device',
+                )}
                 type="success"
                 showIcon
                 icon={<CheckCircleOutlined />}
@@ -601,9 +697,13 @@ const ConnectorPage: React.FC = () => {
                             <Paragraph
                               copyable
                               className="mb-0 text-sm"
-                              style={{ marginBottom: 0, wordBreak: 'break-all' }}
+                              style={{
+                                marginBottom: 0,
+                                wordBreak: 'break-all',
+                              }}
                             >
-                              {accessKeys.command || `curl -k -sSL https://49.232.250.11/install.sh | bash -s -- --access-key=${accessKeys.access_key} --secret-key=${accessKeys.secret_key} --server-http-addr=49.232.250.11 --server-edge-addr=49.232.250.11:30012`}
+                              {accessKeys.command ||
+                                `curl -k -sSL https://49.232.250.11/install.sh | bash -s -- --access-key=${accessKeys.access_key} --secret-key=${accessKeys.secret_key} --server-http-addr=49.232.250.11 --server-edge-addr=49.232.250.11:30012`}
                             </Paragraph>
                           </div>
                         ),
@@ -616,28 +716,39 @@ const ConnectorPage: React.FC = () => {
                             <Paragraph
                               copyable
                               className="mb-0 text-sm"
-                              style={{ marginBottom: 0, wordBreak: 'break-all' }}
+                              style={{
+                                marginBottom: 0,
+                                wordBreak: 'break-all',
+                              }}
                             >
                               {(() => {
                                 // 从后端命令中提取服务器地址，或使用默认值
                                 let serverUrl = 'https://49.232.250.11';
                                 let httpAddr = '49.232.250.11';
                                 let edgeAddr = '49.232.250.11:30012';
-                                
+
                                 if (accessKeys.command) {
                                   // 从命令中提取 URL（例如：curl -k -sSL https://xxx/install.sh）
-                                  const urlMatch = accessKeys.command.match(/https?:\/\/[^\s\/]+/);
+                                  const urlMatch =
+                                    accessKeys.command.match(
+                                      /https?:\/\/[^\s\/]+/,
+                                    );
                                   if (urlMatch) {
                                     serverUrl = urlMatch[0];
-                                    httpAddr = serverUrl.replace(/^https?:\/\//, '');
+                                    httpAddr = serverUrl.replace(
+                                      /^https?:\/\//,
+                                      '',
+                                    );
                                     // 提取 edge 地址（--server-edge-addr=xxx）
-                                    const edgeMatch = accessKeys.command.match(/--server-edge-addr=([^\s]+)/);
+                                    const edgeMatch = accessKeys.command.match(
+                                      /--server-edge-addr=([^\s]+)/,
+                                    );
                                     if (edgeMatch) {
                                       edgeAddr = edgeMatch[1];
                                     }
                                   }
                                 }
-                                
+
                                 // 使用 curl.exe 下载脚本，然后使用 PowerShell 执行（Windows 10+ 内置）
                                 // 注意：PowerShell 中 curl 是 Invoke-WebRequest 的别名，需要使用 curl.exe
                                 // 使用分号分隔命令，PowerShell 不支持 &&
@@ -652,13 +763,21 @@ const ConnectorPage: React.FC = () => {
                   />
                 </div>
                 <Alert
-                  message={tr('请妥善保管以上密钥信息，关闭后将无法再次查看', 'Keep keys safe. They cannot be viewed again after closing')}
+                  message={tr(
+                    '请妥善保管以上密钥信息，关闭后将无法再次查看',
+                    'Keep keys safe. They cannot be viewed again after closing',
+                  )}
                   type="warning"
                   showIcon
                   className="mt-4"
                 />
                 <div className="mt-4 text-gray-500 text-sm">
-                  <p>{tr('支持的操作系统：Linux (x86_64, arm64)、Windows (x86_64)、macOS (x86_64, arm64)', 'Supported OS: Linux (x86_64, arm64), Windows (x86_64), macOS (x86_64, arm64)')}</p>
+                  <p>
+                    {tr(
+                      '支持的操作系统：Linux (x86_64, arm64)、Windows (x86_64)、macOS (x86_64, arm64)',
+                      'Supported OS: Linux (x86_64, arm64), Windows (x86_64), macOS (x86_64, arm64)',
+                    )}
+                  </p>
                 </div>
               </div>
             </>
@@ -666,19 +785,22 @@ const ConnectorPage: React.FC = () => {
             <Result
               status="error"
               title={tr('未获取到密钥信息', 'Missing key information')}
-              subTitle={tr('请返回上一步重新创建', 'Please go back and create again')}
+              subTitle={tr(
+                '请返回上一步重新创建',
+                'Please go back and create again',
+              )}
             />
           )}
         </StepsForm.StepForm>
 
-        <StepsForm.StepForm
-          name="done"
-          title={tr('完成', 'Done')}
-        >
+        <StepsForm.StepForm name="done" title={tr('完成', 'Done')}>
           <Result
             status="success"
             title={tr('连接器创建成功', 'Edge created successfully')}
-            subTitle={tr('安装完成后，连接器将自动上线。您可以在连接器列表中查看状态。', 'After installation, edge will come online automatically. You can check status in edge list.')}
+            subTitle={tr(
+              '安装完成后，连接器将自动上线。您可以在连接器列表中查看状态。',
+              'After installation, edge will come online automatically. You can check status in edge list.',
+            )}
           />
         </StepsForm.StepForm>
       </StepsForm>
@@ -696,21 +818,17 @@ const ConnectorPage: React.FC = () => {
           name="name"
           label={tr('连接器名称', 'Edge Name')}
           placeholder={tr('请输入连接器名称', 'Please input edge name')}
-          rules={[{ required: true, message: tr('请输入连接器名称', 'Please input edge name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入连接器名称', 'Please input edge name'),
+            },
+          ]}
         />
         <ProFormTextArea
           name="description"
           label={tr('描述', 'Description')}
           placeholder={tr('请输入连接器描述', 'Please input description')}
-        />
-        <ProFormSelect
-          name="status"
-          label={tr('运行状态', 'Runtime Status')}
-          options={[
-            { label: tr('运行中', 'Running'), value: 1 },
-            { label: tr('已停止', 'Stopped'), value: 2 },
-          ]}
-          placeholder={tr('请选择运行状态', 'Please select runtime status')}
         />
       </ModalForm>
 
@@ -733,19 +851,34 @@ const ConnectorPage: React.FC = () => {
           <div className="text-center py-12">
             <Spin
               indicator={<LoadingOutlined style={{ fontSize: 32 }} spin />}
-              tip={tr('正在扫描内网应用...', 'Scanning intranet applications...')}
+              tip={tr(
+                '正在扫描内网应用...',
+                'Scanning intranet applications...',
+              )}
             />
           </div>
         ) : scanTask ? (
           <>
             <div className="mb-4 flex justify-between items-center">
               <Text type="secondary">
-                {tr('扫描状态', 'Scan Status')}: {scanTask.task_status === 'pending' ? tr('扫描中', 'Scanning') : scanTask.task_status === 'running' ? tr('扫描中', 'Scanning') : scanTask.task_status === 'completed' ? tr('已完成', 'Completed') : scanTask.task_status === 'failed' ? tr('失败', 'Failed') : scanTask.task_status}
+                {tr('扫描状态', 'Scan Status')}:{' '}
+                {scanTask.task_status === 'pending'
+                  ? tr('扫描中', 'Scanning')
+                  : scanTask.task_status === 'running'
+                  ? tr('扫描中', 'Scanning')
+                  : scanTask.task_status === 'completed'
+                  ? tr('已完成', 'Completed')
+                  : scanTask.task_status === 'failed'
+                  ? tr('失败', 'Failed')
+                  : scanTask.task_status}
                 {scanTask.error && (
-                  <Text type="danger" className="ml-2">{scanTask.error}</Text>
+                  <Text type="danger" className="ml-2">
+                    {scanTask.error}
+                  </Text>
                 )}
               </Text>
-              {(scanTask.task_status === 'completed' || scanTask.task_status === 'failed') && (
+              {(scanTask.task_status === 'completed' ||
+                scanTask.task_status === 'failed') && (
                 <Button size="small" onClick={handleRescan} loading={scanning}>
                   {tr('重新扫描', 'Rescan')}
                 </Button>
@@ -760,9 +893,11 @@ const ConnectorPage: React.FC = () => {
                   const ip = parts[0];
                   const port = parseInt(parts[1], 10);
                   const protocol = parts[2] || 'tcp';
-                  
+
                   // 根据端口推断应用类型
-                  const detectApplicationTypeByPort = (port: number): string => {
+                  const detectApplicationTypeByPort = (
+                    port: number,
+                  ): string => {
                     const portToType: Record<number, string> = {
                       22: 'SSH',
                       80: 'HTTP',
@@ -775,39 +910,48 @@ const ConnectorPage: React.FC = () => {
                     };
                     return portToType[port] || protocol.toUpperCase();
                   };
-                  
+
                   const appType = detectApplicationTypeByPort(port);
                   const displayText = `${ip}:${port}`;
-                  
+
                   return (
                     <List.Item
                       actions={[
-                        <Button key="add" type="link" onClick={() => handleAddDiscoveredApp(app)}>
+                        <Button
+                          key="add"
+                          type="link"
+                          onClick={() => handleAddDiscoveredApp(app)}
+                        >
                           添加
                         </Button>,
                       ]}
                     >
-                      <List.Item.Meta 
-                        title={displayText} 
+                      <List.Item.Meta
+                        title={displayText}
                         description={
                           <Space>
                             <Tag color="blue">{appType}</Tag>
                             <span>扫描到的内网服务</span>
                           </Space>
-                        } 
+                        }
                       />
                     </List.Item>
                   );
                 }}
               />
-            ) : (scanTask.task_status === 'pending' || scanTask.task_status === 'running') ? (
+            ) : scanTask.task_status === 'pending' ||
+              scanTask.task_status === 'running' ? (
               <div className="text-center py-12 text-gray-400">扫描中...</div>
             ) : (
-              <div className="text-center py-12 text-gray-400">未扫描到可用应用</div>
+              <div className="text-center py-12 text-gray-400">
+                未扫描到可用应用
+              </div>
             )}
           </>
         ) : (
-          <div className="text-center py-12 text-gray-400">点击刷新开始扫描</div>
+          <div className="text-center py-12 text-gray-400">
+            点击刷新开始扫描
+          </div>
         )}
       </Drawer>
     </PageContainer>

--- a/web/src/pages/Device/index.tsx
+++ b/web/src/pages/Device/index.tsx
@@ -1,3 +1,17 @@
+import { useI18n } from '@/i18n';
+import {
+  getDeviceDetail,
+  getDeviceList,
+  updateDevice,
+} from '@/services/api';
+import { formatMBSize } from '@/utils/format';
+import { executeAction, tableRequest } from '@/utils/request';
+import {
+  buildSearchParams,
+  defaultPagination,
+  defaultSearch,
+} from '@/utils/tableConfig';
+import { DesktopOutlined } from '@ant-design/icons';
 import {
   ActionType,
   ModalForm,
@@ -8,14 +22,8 @@ import {
   ProFormTextArea,
   ProTable,
 } from '@ant-design/pro-components';
-import { Drawer, Space, Tag, Popconfirm, Badge, Tooltip, message } from 'antd';
-import { DesktopOutlined } from '@ant-design/icons';
+import { Badge, Drawer, Space, Tag } from 'antd';
 import { useRef, useState } from 'react';
-import { getDeviceList, getDeviceDetail, updateDevice, deleteDevice } from '@/services/api';
-import { executeAction, tableRequest } from '@/utils/request';
-import { defaultPagination, defaultSearch, buildSearchParams } from '@/utils/tableConfig';
-import { formatMBSize } from '@/utils/format';
-import { useI18n } from '@/i18n';
 
 const DevicePage: React.FC = () => {
   const { tr, locale } = useI18n();
@@ -47,10 +55,11 @@ const DevicePage: React.FC = () => {
   const handleEdit = async (values: any) => {
     if (!currentRow?.id) return false;
     return executeAction(
-      () => updateDevice(currentRow.id, {
-        name: values.name,
-        description: values.description,
-      }),
+      () =>
+        updateDevice(currentRow.id, {
+          name: values.name,
+          description: values.description,
+        }),
       {
         successMessage: tr('更新成功', 'Updated successfully'),
         errorMessage: tr('更新失败', 'Update failed'),
@@ -60,19 +69,6 @@ const DevicePage: React.FC = () => {
         },
       },
     );
-  };
-
-  const handleDelete = async (id: number, online?: number) => {
-    // 如果设备在线，不允许删除
-    if (online === 1) {
-      message.warning(tr('在线设备不允许删除，请先断开连接', 'Online devices cannot be deleted'));
-      return;
-    }
-    await executeAction(() => deleteDevice(id), {
-      successMessage: tr('删除成功', 'Deleted successfully'),
-      errorMessage: tr('删除失败', 'Delete failed'),
-      onSuccess: reload,
-    });
   };
 
   const columns: ProColumns<API.Device>[] = [
@@ -99,7 +95,9 @@ const DevicePage: React.FC = () => {
       render: (_, record) => (
         <Badge
           status={record.online === 1 ? 'success' : 'default'}
-          text={record.online === 1 ? tr('在线', 'Online') : tr('离线', 'Offline')}
+          text={
+            record.online === 1 ? tr('在线', 'Online') : tr('离线', 'Offline')
+          }
         />
       ),
     },
@@ -120,7 +118,11 @@ const DevicePage: React.FC = () => {
       dataIndex: 'cpu',
       width: 80,
       search: false,
-      render: (cpu) => <Tag>{cpu} {tr('核', 'cores')}</Tag>,
+      render: (cpu) => (
+        <Tag>
+          {cpu} {tr('核', 'cores')}
+        </Tag>
+      ),
     },
     {
       title: tr('内存', 'Memory'),
@@ -144,21 +146,28 @@ const DevicePage: React.FC = () => {
       ellipsis: true,
       render: (_, record) => {
         const interfaces = record.interfaces;
-        if (!interfaces || !Array.isArray(interfaces) || interfaces.length === 0) return '-';
+        if (
+          !interfaces ||
+          !Array.isArray(interfaces) ||
+          interfaces.length === 0
+        )
+          return '-';
         return (
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
-            {interfaces.map((iface, index) => {
-              if (!iface || !iface.name) return null;
-              // 过滤出 IPv4 地址
-              const ipv4 = Array.isArray(iface.ip)
-                ? iface.ip.filter((ip: string) => ip && !ip.includes(':'))
-                : [];
-              return (
-                <Tag key={index} style={{ margin: 0 }}>
-                  {iface.name}: {ipv4.length > 0 ? ipv4.join(', ') : '-'}
-                </Tag>
-              );
-            }).filter(Boolean)}
+            {interfaces
+              .map((iface, index) => {
+                if (!iface || !iface.name) return null;
+                // 过滤出 IPv4 地址
+                const ipv4 = Array.isArray(iface.ip)
+                  ? iface.ip.filter((ip: string) => ip && !ip.includes(':'))
+                  : [];
+                return (
+                  <Tag key={index} style={{ margin: 0 }}>
+                    {iface.name}: {ipv4.length > 0 ? ipv4.join(', ') : '-'}
+                  </Tag>
+                );
+              })
+              .filter(Boolean)}
           </div>
         );
       },
@@ -167,9 +176,13 @@ const DevicePage: React.FC = () => {
       title: tr('网卡IP', 'NIC IP'),
       dataIndex: 'ip',
       hideInTable: true,
-      tooltip: locale === 'en-US' ? 'Supports searching any NIC IP address' : '支持搜索设备的任意网卡IP地址',
+      tooltip:
+        locale === 'en-US'
+          ? 'Supports searching any NIC IP address'
+          : '支持搜索设备的任意网卡IP地址',
       fieldProps: {
-        placeholder: locale === 'en-US' ? 'Please input NIC IP' : '请输入网卡IP',
+        placeholder:
+          locale === 'en-US' ? 'Please input NIC IP' : '请输入网卡IP',
       },
     },
     {
@@ -189,40 +202,20 @@ const DevicePage: React.FC = () => {
     {
       title: tr('操作', 'Actions'),
       valueType: 'option',
-      width: 150,
+      width: 110,
       fixed: 'right',
       align: 'center',
       render: (_, record) => (
         <Space size="small">
-          <a onClick={() => handleViewDetail(record)}>
-            {tr('详情', 'Detail')}
-          </a>
-          <a onClick={() => {
-            setCurrentRow(record);
-            setEditModalVisible(true);
-          }}>
+          <a onClick={() => handleViewDetail(record)}>{tr('详情', 'Detail')}</a>
+          <a
+            onClick={() => {
+              setCurrentRow(record);
+              setEditModalVisible(true);
+            }}
+          >
             {tr('编辑', 'Edit')}
           </a>
-          {record.online === 1 ? (
-            <Tooltip title={tr('在线设备不允许删除，请先断开连接', 'Online devices cannot be deleted')}>
-              <a style={{ color: '#d9d9d9', cursor: 'not-allowed' }}>
-                {tr('删除', 'Delete')}
-              </a>
-            </Tooltip>
-          ) : (
-            <Popconfirm
-              title={tr('确定要删除这个设备吗？', 'Delete this device?')}
-              description={tr('删除后无法恢复，请谨慎操作', 'This action cannot be undone')}
-              onConfirm={() => handleDelete(record.id, record.online)}
-              okText={tr('确定', 'Confirm')}
-              cancelText={tr('取消', 'Cancel')}
-              okButtonProps={{ danger: true }}
-            >
-              <a style={{ color: '#ff4d4f' }}>
-                {tr('删除', 'Delete')}
-              </a>
-            </Popconfirm>
-          )}
         </Space>
       ),
     },
@@ -232,21 +225,24 @@ const DevicePage: React.FC = () => {
     <PageContainer>
       <div className="table-search-wrapper">
         <ProTable<API.Device>
-        headerTitle={tr('设备列表', 'Devices')}
-        actionRef={actionRef}
-        rowKey="id"
-        columns={columns}
-        request={async (params) => {
-          const searchParams = buildSearchParams<API.DeviceListParams>(params, ['name', 'ip']);
-          return tableRequest(() => getDeviceList(searchParams), 'devices');
-        }}
-        pagination={defaultPagination}
-        search={{
-          ...defaultSearch,
-          labelWidth: 'auto',
-        }}
-        scroll={{ x: 'max-content' }}
-      />
+          headerTitle={tr('设备列表', 'Devices')}
+          actionRef={actionRef}
+          rowKey="id"
+          columns={columns}
+          request={async (params) => {
+            const searchParams = buildSearchParams<API.DeviceListParams>(
+              params,
+              ['name', 'ip'],
+            );
+            return tableRequest(() => getDeviceList(searchParams), 'devices');
+          }}
+          pagination={defaultPagination}
+          search={{
+            ...defaultSearch,
+            labelWidth: 'auto',
+          }}
+          scroll={{ x: 'max-content' }}
+        />
       </div>
 
       <Drawer
@@ -261,41 +257,87 @@ const DevicePage: React.FC = () => {
             column={1}
             dataSource={currentRow}
             columns={[
-              { title: tr('设备 ID', 'Device ID'), dataIndex: 'id', copyable: true },
+              {
+                title: tr('设备 ID', 'Device ID'),
+                dataIndex: 'id',
+                copyable: true,
+              },
               { title: tr('设备名称', 'Device Name'), dataIndex: 'name' },
               { title: tr('操作系统', 'OS'), dataIndex: 'os' },
               { title: tr('版本', 'Version'), dataIndex: 'version' },
-              { title: 'CPU', dataIndex: 'cpu', render: (cpu) => `${cpu} ${tr('核', 'cores')}` },
-              { title: tr('内存', 'Memory'), dataIndex: 'memory', render: (memory) => formatMBSize(memory as number) },
-              { title: tr('磁盘', 'Disk'), dataIndex: 'disk', render: (disk) => formatMBSize(disk as number) },
+              {
+                title: 'CPU',
+                dataIndex: 'cpu',
+                render: (cpu) => `${cpu} ${tr('核', 'cores')}`,
+              },
+              {
+                title: tr('内存', 'Memory'),
+                dataIndex: 'memory',
+                render: (memory) => formatMBSize(memory as number),
+              },
+              {
+                title: tr('磁盘', 'Disk'),
+                dataIndex: 'disk',
+                render: (disk) => formatMBSize(disk as number),
+              },
               {
                 title: tr('网卡信息', 'NIC Information'),
                 dataIndex: 'interfaces',
                 render: (_, record) => {
                   const interfaces = record.interfaces;
-                  if (!interfaces || !Array.isArray(interfaces) || interfaces.length === 0) return '-';
+                  if (
+                    !interfaces ||
+                    !Array.isArray(interfaces) ||
+                    interfaces.length === 0
+                  )
+                    return '-';
                   return (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                      {interfaces.map((iface, index) => {
-                        if (!iface || !iface.name) return null;
-                        // 过滤出 IPv4 地址
-                        const ipv4 = Array.isArray(iface.ip)
-                          ? iface.ip.filter((ip: string) => ip && !ip.includes(':'))
-                          : [];
-                        return (
-                          <div key={index}>
-                            <Tag>{iface.name}</Tag> {ipv4.length > 0 ? ipv4.join(', ') : '-'}
-                            {iface.mac && <div style={{ fontSize: '12px', color: '#999' }}>MAC: {iface.mac}</div>}
-                          </div>
-                        );
-                      }).filter(Boolean)}
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '4px',
+                      }}
+                    >
+                      {interfaces
+                        .map((iface, index) => {
+                          if (!iface || !iface.name) return null;
+                          // 过滤出 IPv4 地址
+                          const ipv4 = Array.isArray(iface.ip)
+                            ? iface.ip.filter(
+                                (ip: string) => ip && !ip.includes(':'),
+                              )
+                            : [];
+                          return (
+                            <div key={index}>
+                              <Tag>{iface.name}</Tag>{' '}
+                              {ipv4.length > 0 ? ipv4.join(', ') : '-'}
+                              {iface.mac && (
+                                <div
+                                  style={{ fontSize: '12px', color: '#999' }}
+                                >
+                                  MAC: {iface.mac}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })
+                        .filter(Boolean)}
                     </div>
                   );
-                }
+                },
               },
               { title: tr('描述', 'Description'), dataIndex: 'description' },
-              { title: tr('创建时间', 'Created At'), dataIndex: 'created_at', valueType: 'dateTime' },
-              { title: tr('更新时间', 'Updated At'), dataIndex: 'updated_at', valueType: 'dateTime' },
+              {
+                title: tr('创建时间', 'Created At'),
+                dataIndex: 'created_at',
+                valueType: 'dateTime',
+              },
+              {
+                title: tr('更新时间', 'Updated At'),
+                dataIndex: 'updated_at',
+                valueType: 'dateTime',
+              },
             ]}
           />
         )}
@@ -314,7 +356,12 @@ const DevicePage: React.FC = () => {
           name="name"
           label={tr('设备名称', 'Device Name')}
           placeholder={tr('请输入设备名称', 'Please input device name')}
-          rules={[{ required: true, message: tr('请输入设备名称', 'Please input device name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入设备名称', 'Please input device name'),
+            },
+          ]}
         />
         <ProFormTextArea
           name="description"

--- a/web/src/pages/Proxy/index.tsx
+++ b/web/src/pages/Proxy/index.tsx
@@ -1,3 +1,23 @@
+import { CreateButton, DeleteLink, EditLink } from '@/components/TableButtons';
+import { useI18n } from '@/i18n';
+import {
+  createProxy,
+  deleteProxy,
+  deleteProxyFirewall,
+  getApplicationList,
+  getClientIP,
+  getProxyFirewall,
+  getProxyList,
+  updateProxy,
+  upsertProxyFirewall,
+} from '@/services/api';
+import { executeAction, tableRequest } from '@/utils/request';
+import {
+  buildSearchParams,
+  defaultPagination,
+  defaultSearch,
+} from '@/utils/tableConfig';
+import { CheckCircleOutlined } from '@ant-design/icons';
 import {
   ActionType,
   ModalForm,
@@ -9,25 +29,23 @@ import {
   ProFormTextArea,
   ProTable,
 } from '@ant-design/pro-components';
-import { Space, Tag, Typography, Switch, Alert, Tooltip, message, Button, Drawer, Input, Table, Spin, Popconfirm } from 'antd';
-import { CheckCircleOutlined } from '@ant-design/icons';
-import { useRef, useState, useEffect } from 'react';
-import { useSearchParams, useLocation } from '@umijs/max';
+import { useLocation, useSearchParams } from '@umijs/max';
 import {
-  getProxyList,
-  createProxy,
-  updateProxy,
-  deleteProxy,
-  getApplicationList,
-  getProxyFirewall,
-  upsertProxyFirewall,
-  deleteProxyFirewall,
-  getClientIP,
-} from '@/services/api';
-import { executeAction, tableRequest } from '@/utils/request';
-import { CreateButton, EditLink, DeleteLink } from '@/components/TableButtons';
-import { defaultPagination, defaultSearch, buildSearchParams } from '@/utils/tableConfig';
-import { useI18n } from '@/i18n';
+  Alert,
+  Button,
+  Drawer,
+  Input,
+  Popconfirm,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from 'antd';
+import { useEffect, useRef, useState } from 'react';
 
 const { Text } = Typography;
 
@@ -40,12 +58,18 @@ const ProxyPage: React.FC = () => {
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [currentRow, setCurrentRow] = useState<API.Proxy>();
-  const [initialApplicationId, setInitialApplicationId] = useState<number | undefined>();
+  const [initialApplicationId, setInitialApplicationId] = useState<
+    number | undefined
+  >();
   const [applicationOptions, setApplicationOptions] = useState<
     { label: string; value: number; application_type?: string }[]
   >([]);
-  const [applicationMap, setApplicationMap] = useState<Map<number, API.Application>>(new Map());
-  const [selectedApplicationId, setSelectedApplicationId] = useState<number | undefined>();
+  const [applicationMap, setApplicationMap] = useState<
+    Map<number, API.Application>
+  >(new Map());
+  const [selectedApplicationId, setSelectedApplicationId] = useState<
+    number | undefined
+  >();
   const hasProcessedUrlRef = useRef(false); // 使用 ref 跟踪是否已处理过 URL 参数
 
   // 防火墙 Drawer 状态
@@ -71,7 +95,9 @@ const ProxyPage: React.FC = () => {
   // IPv4 地址或带前缀的 IPv4 CIDR。纯 IP 保存时会自动补 /32。
   const isValidCIDR = (value: string): boolean => {
     const trimmed = value.trim();
-    return /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[12][0-9]|3[0-2]))?$/.test(trimmed);
+    return /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[12][0-9]|3[0-2]))?$/.test(
+      trimmed,
+    );
   };
   const normalizeCIDR = (value: string) => {
     const trimmed = value.trim();
@@ -89,15 +115,25 @@ const ProxyPage: React.FC = () => {
     });
     setNewFirewallCIDR('');
     setClientIP(null);
-    getClientIP().then((res) => {
-      if (res?.data?.ip) setClientIP(res.data.ip);
-    }).catch(() => {});
+    getClientIP()
+      .then((res) => {
+        if (res?.data?.ip) setClientIP(res.data.ip);
+      })
+      .catch(() => {});
 
     try {
       const res = await getProxyFirewall(record.id);
       if (res.code !== 200 || !res.data) {
-        message.error(res.message || tr('获取防火墙失败', 'Failed to load firewall'));
-        setFirewallDrawer({ open: false, loading: false, draftCIDRs: [], updatedAt: '', hasRule: false });
+        message.error(
+          res.message || tr('获取防火墙失败', 'Failed to load firewall'),
+        );
+        setFirewallDrawer({
+          open: false,
+          loading: false,
+          draftCIDRs: [],
+          updatedAt: '',
+          hasRule: false,
+        });
         return;
       }
       const hasRule = !!res.data.updated_at;
@@ -110,8 +146,16 @@ const ProxyPage: React.FC = () => {
         hasRule,
       });
     } catch (err: any) {
-      message.error(err?.message || tr('获取防火墙失败', 'Failed to load firewall'));
-      setFirewallDrawer({ open: false, loading: false, draftCIDRs: [], updatedAt: '', hasRule: false });
+      message.error(
+        err?.message || tr('获取防火墙失败', 'Failed to load firewall'),
+      );
+      setFirewallDrawer({
+        open: false,
+        loading: false,
+        draftCIDRs: [],
+        updatedAt: '',
+        hasRule: false,
+      });
     }
   };
 
@@ -136,7 +180,10 @@ const ProxyPage: React.FC = () => {
       message.warning(tr('该 CIDR 已存在', 'This CIDR already exists'));
       return;
     }
-    setFirewallDrawer((prev) => ({ ...prev, draftCIDRs: [...prev.draftCIDRs, cidr] }));
+    setFirewallDrawer((prev) => ({
+      ...prev,
+      draftCIDRs: [...prev.draftCIDRs, cidr],
+    }));
     setNewFirewallCIDR('');
   };
 
@@ -152,7 +199,10 @@ const ProxyPage: React.FC = () => {
     if (!record?.id) return;
     setFirewallSaving(true);
     await executeAction(
-      () => upsertProxyFirewall(record.id, { allowed_cidrs: firewallDrawer.draftCIDRs }),
+      () =>
+        upsertProxyFirewall(record.id, {
+          allowed_cidrs: firewallDrawer.draftCIDRs,
+        }),
       {
         successMessage:
           firewallDrawer.draftCIDRs.length === 0
@@ -160,7 +210,13 @@ const ProxyPage: React.FC = () => {
             : tr('防火墙已更新', 'Firewall updated'),
         errorMessage: tr('防火墙更新失败', 'Failed to update firewall'),
         onSuccess: () => {
-          setFirewallDrawer({ open: false, loading: false, draftCIDRs: [], updatedAt: '', hasRule: false });
+          setFirewallDrawer({
+            open: false,
+            loading: false,
+            draftCIDRs: [],
+            updatedAt: '',
+            hasRule: false,
+          });
         },
       },
     );
@@ -174,7 +230,13 @@ const ProxyPage: React.FC = () => {
       successMessage: tr('已恢复为放行全部', 'Reset to allow-all'),
       errorMessage: tr('操作失败', 'Operation failed'),
       onSuccess: () => {
-        setFirewallDrawer({ open: false, loading: false, draftCIDRs: [], updatedAt: '', hasRule: false });
+        setFirewallDrawer({
+          open: false,
+          loading: false,
+          draftCIDRs: [],
+          updatedAt: '',
+          hasRule: false,
+        });
       },
     });
   };
@@ -183,12 +245,12 @@ const ProxyPage: React.FC = () => {
   useEffect(() => {
     // 如果已经处理过 URL 参数，不再重复处理
     if (hasProcessedUrlRef.current) return;
-    
+
     // 优先从 searchParams 读取
     let applicationId = searchParams.get('application_id');
     let applicationName = searchParams.get('application_name');
     let autoCreate = searchParams.get('autoCreate');
-    
+
     // 如果 searchParams 没有，从 location.search 读取
     if (location.search) {
       const urlParams = new URLSearchParams(location.search);
@@ -202,74 +264,79 @@ const ProxyPage: React.FC = () => {
         autoCreate = urlParams.get('autoCreate');
       }
     }
-    
+
     // 如果 application_id 存在，设置初始值
     if (applicationId) {
       const id = parseInt(applicationId, 10);
       if (!isNaN(id)) {
         setInitialApplicationId(id);
-        
+
         // 如果 URL 中有应用名称，立即添加到 options 中（避免等待列表加载）
         if (applicationName) {
           const decodedName = decodeURIComponent(applicationName);
           setApplicationOptions((prev) => {
             // 检查是否已经在 options 中
-            const exists = prev.some(opt => opt.value === id);
+            const exists = prev.some((opt) => opt.value === id);
             if (exists) {
               // 如果已存在，更新 label（使用URL中的名称）
-              return prev.map(opt => 
-                opt.value === id ? { ...opt, label: decodedName } : opt
+              return prev.map((opt) =>
+                opt.value === id ? { ...opt, label: decodedName } : opt,
               );
             }
             // 如果不存在，添加到 options 中
             return [...prev, { label: decodedName, value: id }];
           });
         }
-        
+
         // 重新加载应用列表，确保包含完整信息（IP和端口）
-        getApplicationList({ page_size: 100 }).then((res) => {
-          const apps = res.data?.applications || [];
-          const appMap = new Map<number, API.Application>();
-          apps.forEach((app: API.Application) => {
-            appMap.set(app.id, app);
-          });
-          setApplicationMap(appMap);
-          
-          const options =
-            apps.map((item: API.Application) => ({
-              label: `${item.name} (${item.ip}:${item.port})`,
-              value: item.id,
-              application_type: item.application_type,
-            })) || [];
-          // 如果URL中有应用名称，确保对应的选项存在（即使列表中没有）
-          if (applicationName) {
-            const decodedName = decodeURIComponent(applicationName);
-            const exists = options.some(opt => opt.value === id);
-            if (!exists) {
-              // 尝试从 appMap 中获取应用类型，如果找不到则默认为空
-              const app = appMap.get(id);
-              options.push({ 
-                label: decodedName, 
-                value: id,
-                application_type: app?.application_type || '',
+        getApplicationList({ page_size: 100 })
+          .then((res) => {
+            const apps = res.data?.applications || [];
+            const appMap = new Map<number, API.Application>();
+            apps.forEach((app: API.Application) => {
+              appMap.set(app.id, app);
+            });
+            setApplicationMap(appMap);
+
+            const options =
+              apps.map((item: API.Application) => ({
+                label: `${item.name} (${item.ip}:${item.port})`,
+                value: item.id,
+                application_type: item.application_type,
+              })) || [];
+            // 如果URL中有应用名称，确保对应的选项存在（即使列表中没有）
+            if (applicationName) {
+              const decodedName = decodeURIComponent(applicationName);
+              const exists = options.some((opt) => opt.value === id);
+              if (!exists) {
+                // 尝试从 appMap 中获取应用类型，如果找不到则默认为空
+                const app = appMap.get(id);
+                options.push({
+                  label: decodedName,
+                  value: id,
+                  application_type: app?.application_type || '',
+                });
+              }
+            }
+            setApplicationOptions(options);
+          })
+          .catch(() => {
+            // 忽略错误，但如果URL中有应用名称，至少保留它
+            if (applicationName) {
+              const decodedName = decodeURIComponent(applicationName);
+              setApplicationOptions((prev) => {
+                const exists = prev.some((opt) => opt.value === id);
+                if (exists) return prev;
+                return [
+                  ...prev,
+                  { label: decodedName, value: id, application_type: '' },
+                ];
               });
             }
-          }
-          setApplicationOptions(options);
-        }).catch(() => {
-          // 忽略错误，但如果URL中有应用名称，至少保留它
-          if (applicationName) {
-            const decodedName = decodeURIComponent(applicationName);
-            setApplicationOptions((prev) => {
-              const exists = prev.some(opt => opt.value === id);
-              if (exists) return prev;
-              return [...prev, { label: decodedName, value: id, application_type: '' }];
-            });
-          }
-        });
+          });
       }
     }
-    
+
     // 如果 autoCreate 为 true，自动打开对话框
     if (autoCreate === 'true') {
       hasProcessedUrlRef.current = true; // 标记为已处理
@@ -299,7 +366,7 @@ const ProxyPage: React.FC = () => {
           appMap.set(app.id, app);
         });
         setApplicationMap(appMap);
-        
+
         const options =
           apps.map((item: API.Application) => ({
             label: `${item.name} (${item.ip}:${item.port})`,
@@ -315,20 +382,52 @@ const ProxyPage: React.FC = () => {
     loadApplications();
   }, []);
 
-
-
   const reload = () => actionRef.current?.reload();
+
+  const effectiveStatusMeta = (record: API.Proxy) => {
+    const status =
+      record.effective_status ||
+      (record.status === 'running' ? 'active' : 'stopped');
+    const map: Record<
+      string,
+      { text: string; color: string; reason?: string }
+    > = {
+      active: { text: tr('可用', 'Active'), color: 'success' },
+      stopped: {
+        text: tr('不可用', 'Unavailable'),
+        color: 'default',
+        reason: tr('访问未启用', 'Access disabled'),
+      },
+      edge_stopped: {
+        text: tr('不可用', 'Unavailable'),
+        color: 'warning',
+        reason: tr('连接器已禁用', 'Edge disabled'),
+      },
+      edge_offline: {
+        text: tr('不可用', 'Unavailable'),
+        color: 'processing',
+        reason: tr('连接器离线', 'Edge offline'),
+      },
+      invalid: {
+        text: tr('不可用', 'Unavailable'),
+        color: 'error',
+        reason: tr('配置无效', 'Invalid'),
+      },
+    };
+    return map[status] || { text: status, color: 'default' };
+  };
 
   const handleAdd = async (values: any) => {
     const createPort = values.port || undefined;
-    
+
     const result = await executeAction(
-      () => createProxy({
-        name: values.name,
-        description: values.description,
-        port: createPort,
-        application_id: values.application_id,
-      }),
+      () =>
+        createProxy({
+          name: values.name,
+          description: values.description,
+          port: createPort,
+          application_id: values.application_id,
+        }),
       {
         successMessage: tr('创建成功', 'Created successfully'),
         errorMessage: tr('创建失败', 'Create failed'),
@@ -338,21 +437,22 @@ const ProxyPage: React.FC = () => {
         },
       },
     );
-    
+
     setCreateModalVisible(false);
     reload();
-    
+
     return result;
   };
 
   const handleEdit = async (values: any) => {
     if (!currentRow?.id) return false;
     return executeAction(
-      () => updateProxy(currentRow.id, {
-        name: values.name,
-        description: values.description,
-        port: values.port,
-      }),
+      () =>
+        updateProxy(currentRow.id, {
+          name: values.name,
+          description: values.description,
+          port: values.port,
+        }),
       {
         successMessage: tr('更新成功', 'Updated successfully'),
         errorMessage: tr('更新失败', 'Update failed'),
@@ -406,8 +506,16 @@ const ProxyPage: React.FC = () => {
             <Space>
               <Text>{record.application.name}</Text>
               {record.application.application_type === 'http' && (
-                <Tooltip title={<span style={{ fontSize: '11px' }}>{tr('已开启 HTTPS', 'HTTPS enabled')}</span>}>
-                  <CheckCircleOutlined style={{ color: '#52c41a', fontSize: 16 }} />
+                <Tooltip
+                  title={
+                    <span style={{ fontSize: '11px' }}>
+                      {tr('已开启 HTTPS', 'HTTPS enabled')}
+                    </span>
+                  }
+                >
+                  <CheckCircleOutlined
+                    style={{ color: '#52c41a', fontSize: 16 }}
+                  />
                 </Tooltip>
               )}
             </Space>
@@ -420,14 +528,19 @@ const ProxyPage: React.FC = () => {
         ),
     },
     {
-      title: tr('状态', 'Status'),
-      dataIndex: 'status',
-      width: 100,
+      title: tr('当前状态', 'Current Status'),
+      dataIndex: 'effective_status',
+      width: 140,
       search: false,
-      valueEnum: {
-        running: { text: tr('运行中', 'Running'), status: 'Success' },
-        stopped: { text: tr('已停止', 'Stopped'), status: 'Default' },
-        error: { text: tr('异常', 'Error'), status: 'Error' },
+      render: (_, record) => {
+        const meta = effectiveStatusMeta(record);
+        return (
+          <Tooltip
+            title={record.effective_status_message || meta.reason || meta.text}
+          >
+            <Tag color={meta.color}>{meta.text}</Tag>
+          </Tooltip>
+        );
       },
     },
     {
@@ -442,14 +555,17 @@ const ProxyPage: React.FC = () => {
           onChange={async (checked) => {
             const newStatus = checked ? 'running' : 'stopped';
             await executeAction(
-              () => updateProxy(record.id, {
-                name: record.name,
-                description: record.description,
-                port: record.port,
-                status: newStatus,
-              }),
+              () =>
+                updateProxy(record.id, {
+                  name: record.name,
+                  description: record.description,
+                  port: record.port,
+                  status: newStatus,
+                }),
               {
-                successMessage: checked ? tr('已启用', 'Enabled') : tr('已停用', 'Disabled'),
+                successMessage: checked
+                  ? tr('已启用', 'Enabled')
+                  : tr('已停用', 'Disabled'),
                 errorMessage: tr('操作失败', 'Operation failed'),
                 onSuccess: reload,
               },
@@ -473,28 +589,35 @@ const ProxyPage: React.FC = () => {
       align: 'center',
       render: (_, record) => {
         const accessUrl = record.access_url;
-        const url = accessUrl && typeof accessUrl === 'string'
-          ? (accessUrl.startsWith('http://') || accessUrl.startsWith('https://') 
-              ? accessUrl 
-              : `https://${accessUrl}`)
-          : null;
-        
+        const url =
+          accessUrl && typeof accessUrl === 'string'
+            ? accessUrl.startsWith('http://') ||
+              accessUrl.startsWith('https://')
+              ? accessUrl
+              : `https://${accessUrl}`
+            : null;
+
         return (
           <Space>
-            {url && (
-              <Tooltip title={<span style={{ fontSize: '12px' }}>{accessUrl}</span>}>
-                <Button
-                  type="link"
-                  size="small"
-                  style={{ padding: 0, height: 'auto' }}
-                  onClick={() => {
-                    window.open(url, '_blank');
-                  }}
+            {url &&
+              (record.effective_status ||
+                (record.status === 'running' ? 'active' : 'stopped')) ===
+                'active' && (
+                <Tooltip
+                  title={<span style={{ fontSize: '12px' }}>{accessUrl}</span>}
                 >
-                  {tr('去访问', 'Open')}
-                </Button>
-              </Tooltip>
-            )}
+                  <Button
+                    type="link"
+                    size="small"
+                    style={{ padding: 0, height: 'auto' }}
+                    onClick={() => {
+                      window.open(url, '_blank');
+                    }}
+                  >
+                    {tr('去访问', 'Open')}
+                  </Button>
+                </Tooltip>
+              )}
             <Button
               type="link"
               size="small"
@@ -503,12 +626,18 @@ const ProxyPage: React.FC = () => {
             >
               {tr('防火墙', 'Firewall')}
             </Button>
-            <EditLink onClick={() => {
-              setCurrentRow(record);
-              setEditModalVisible(true);
-            }} />
+            <EditLink
+              onClick={() => {
+                setCurrentRow(record);
+                setEditModalVisible(true);
+              }}
+            />
             <DeleteLink
-              title="确定要删除这个访问吗？"
+              title={tr('确定要删除这个访问吗？', 'Delete this entry?')}
+              description={tr(
+                '将同步停止公网监听并删除访问规则',
+                'The public listener and access rules will be removed together',
+              )}
               onConfirm={() => handleDelete(record.id)}
             />
           </Space>
@@ -521,26 +650,32 @@ const ProxyPage: React.FC = () => {
     <PageContainer title={tr('访问', 'Entries')}>
       <div className="table-search-wrapper">
         <ProTable<API.Proxy>
-        headerTitle={tr('访问列表', 'Entries')}
-        actionRef={actionRef}
-        rowKey="id"
-        columns={columns}
-        request={async (params) => {
-          const searchParams = buildSearchParams<API.ProxyListParams>(params, ['name']);
-          return tableRequest(() => getProxyList(searchParams), 'proxies');
-        }}
-        toolBarRender={() => [
-          <CreateButton key="create" onClick={() => setCreateModalVisible(true)}>
-            {tr('新建访问', 'New Entry')}
-          </CreateButton>,
-        ]}
-        pagination={defaultPagination}
-        search={{
-          ...defaultSearch,
-          labelWidth: 'auto',
-        }}
-        scroll={{ x: 'max-content' }}
-      />
+          headerTitle={tr('访问列表', 'Entries')}
+          actionRef={actionRef}
+          rowKey="id"
+          columns={columns}
+          request={async (params) => {
+            const searchParams = buildSearchParams<API.ProxyListParams>(
+              params,
+              ['name'],
+            );
+            return tableRequest(() => getProxyList(searchParams), 'proxies');
+          }}
+          toolBarRender={() => [
+            <CreateButton
+              key="create"
+              onClick={() => setCreateModalVisible(true)}
+            >
+              {tr('新建访问', 'New Entry')}
+            </CreateButton>,
+          ]}
+          pagination={defaultPagination}
+          search={{
+            ...defaultSearch,
+            labelWidth: 'auto',
+          }}
+          scroll={{ x: 'max-content' }}
+        />
       </div>
 
       <ModalForm
@@ -570,13 +705,23 @@ const ProxyPage: React.FC = () => {
           name="name"
           label={tr('访问名称', 'Entry Name')}
           placeholder={tr('请输入访问名称', 'Please input entry name')}
-          rules={[{ required: true, message: tr('请输入访问名称', 'Please input entry name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入访问名称', 'Please input entry name'),
+            },
+          ]}
         />
         <ProFormSelect
           name="application_id"
           label={tr('关联应用', 'Application')}
           placeholder={tr('请选择要访问的应用', 'Please select an application')}
-          rules={[{ required: true, message: tr('请选择应用', 'Please select an application') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请选择应用', 'Please select an application'),
+            },
+          ]}
           options={applicationOptions}
           fieldProps={{
             onChange: (value: number) => {
@@ -584,22 +729,56 @@ const ProxyPage: React.FC = () => {
             },
           }}
         />
-        {selectedApplicationId && applicationMap.get(selectedApplicationId)?.application_type === 'http' && (
-          <Alert
-            message={<span style={{ fontSize: '11px', lineHeight: '16px', marginBottom: 0, display: 'block' }}>{tr('将开启 HTTPS', 'HTTPS will be enabled')}</span>}
-            description={<span style={{ fontSize: '10px', lineHeight: '14px', marginTop: 0, display: 'block' }}>{tr('HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书', 'HTTP applications will be exposed over HTTPS with configured TLS certificates')}</span>}
-            type="info"
-            icon={<CheckCircleOutlined style={{ color: '#52c41a', fontSize: '14px' }} />}
-            style={{ marginBottom: 16, padding: '8px 12px' }}
-          />
-        )}
+        {selectedApplicationId &&
+          applicationMap.get(selectedApplicationId)?.application_type ===
+            'http' && (
+            <Alert
+              message={
+                <span
+                  style={{
+                    fontSize: '11px',
+                    lineHeight: '16px',
+                    marginBottom: 0,
+                    display: 'block',
+                  }}
+                >
+                  {tr('将开启 HTTPS', 'HTTPS will be enabled')}
+                </span>
+              }
+              description={
+                <span
+                  style={{
+                    fontSize: '10px',
+                    lineHeight: '14px',
+                    marginTop: 0,
+                    display: 'block',
+                  }}
+                >
+                  {tr(
+                    'HTTP 应用将默认使用 HTTPS 协议访问，使用系统配置的 TLS 证书',
+                    'HTTP applications will be exposed over HTTPS with configured TLS certificates',
+                  )}
+                </span>
+              }
+              type="info"
+              icon={
+                <CheckCircleOutlined
+                  style={{ color: '#52c41a', fontSize: '14px' }}
+                />
+              }
+              style={{ marginBottom: 16, padding: '8px 12px' }}
+            />
+          )}
         <ProFormDigit
           name="port"
           label={tr('公网端口', 'Public Port')}
           placeholder={tr('留空自动分配', 'Leave empty for auto allocation')}
           min={1}
           max={65535}
-          extra={tr('映射到公网的端口号，留空则自动分配', 'Mapped public port, empty means auto allocation')}
+          extra={tr(
+            '映射到公网的端口号，留空则自动分配',
+            'Mapped public port, empty means auto allocation',
+          )}
         />
         <ProFormTextArea
           name="description"
@@ -621,7 +800,12 @@ const ProxyPage: React.FC = () => {
           name="name"
           label={tr('访问名称', 'Entry Name')}
           placeholder={tr('请输入访问名称', 'Please input entry name')}
-          rules={[{ required: true, message: tr('请输入访问名称', 'Please input entry name') }]}
+          rules={[
+            {
+              required: true,
+              message: tr('请输入访问名称', 'Please input entry name'),
+            },
+          ]}
         />
         <ProFormDigit
           name="port"
@@ -640,7 +824,9 @@ const ProxyPage: React.FC = () => {
       <Drawer
         title={
           firewallDrawer.record
-            ? `${tr('设置防火墙', 'Configure Firewall')} · ${firewallDrawer.record.name}`
+            ? `${tr('设置防火墙', 'Configure Firewall')} · ${
+                firewallDrawer.record.name
+              }`
             : tr('设置防火墙', 'Configure Firewall')
         }
         open={firewallDrawer.open}
@@ -668,7 +854,11 @@ const ProxyPage: React.FC = () => {
             <Button onClick={closeFirewallDrawer}>
               {tr('取消', 'Cancel')}
             </Button>
-            <Button type="primary" loading={firewallSaving} onClick={handleFirewallSave}>
+            <Button
+              type="primary"
+              loading={firewallSaving}
+              onClick={handleFirewallSave}
+            >
               {tr('保存', 'Save')}
             </Button>
           </Space>
@@ -699,12 +889,21 @@ const ProxyPage: React.FC = () => {
                   'Configure source IP allowlist for this proxy. Takes effect immediately; both HTTP and TCP are filtered at Accept. Supports single IPv4 or CIDR (a bare IP is auto-completed to /32).',
                 )}
               </Text>
-              <div style={{ marginTop: 10, display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+              <div
+                style={{
+                  marginTop: 10,
+                  display: 'flex',
+                  gap: 16,
+                  flexWrap: 'wrap',
+                }}
+              >
                 <Text type="secondary" style={{ fontSize: 12 }}>
-                  {tr('端口', 'Port')}: <strong>{firewallDrawer.record?.port || '-'}</strong>
+                  {tr('端口', 'Port')}:{' '}
+                  <strong>{firewallDrawer.record?.port || '-'}</strong>
                 </Text>
                 <Text type="secondary" style={{ fontSize: 12 }}>
-                  {tr('规则数', 'Rules')}: <strong>{firewallDrawer.draftCIDRs.length}</strong>
+                  {tr('规则数', 'Rules')}:{' '}
+                  <strong>{firewallDrawer.draftCIDRs.length}</strong>
                 </Text>
                 {firewallDrawer.updatedAt && (
                   <Text type="secondary" style={{ fontSize: 12 }}>
@@ -712,28 +911,45 @@ const ProxyPage: React.FC = () => {
                   </Text>
                 )}
               </div>
-              <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <div
+                style={{
+                  marginTop: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+              >
                 <Text type="secondary" style={{ fontSize: 12 }}>
                   {tr('我的 IP', 'My IP')}:{' '}
                   {clientIP ? (
-                    <Text code style={{ fontSize: 12 }}>{clientIP}</Text>
+                    <Text code style={{ fontSize: 12 }}>
+                      {clientIP}
+                    </Text>
                   ) : (
-                    <Text type="secondary" style={{ fontSize: 12 }}>...</Text>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      ...
+                    </Text>
                   )}
                 </Text>
-                {clientIP && !firewallDrawer.draftCIDRs.includes(`${clientIP}/32`) && !firewallDrawer.draftCIDRs.includes(clientIP) && (
-                  <Button
-                    size="small"
-                    type="link"
-                    style={{ padding: 0, fontSize: 12, height: 'auto' }}
-                    onClick={() => addFirewallCIDR(clientIP)}
-                  >
-                    {tr('添加', 'Add')}
-                  </Button>
-                )}
-                {clientIP && (firewallDrawer.draftCIDRs.includes(`${clientIP}/32`) || firewallDrawer.draftCIDRs.includes(clientIP)) && (
-                  <Text type="success" style={{ fontSize: 12 }}>✓ {tr('已添加', 'Added')}</Text>
-                )}
+                {clientIP &&
+                  !firewallDrawer.draftCIDRs.includes(`${clientIP}/32`) &&
+                  !firewallDrawer.draftCIDRs.includes(clientIP) && (
+                    <Button
+                      size="small"
+                      type="link"
+                      style={{ padding: 0, fontSize: 12, height: 'auto' }}
+                      onClick={() => addFirewallCIDR(clientIP)}
+                    >
+                      {tr('添加', 'Add')}
+                    </Button>
+                  )}
+                {clientIP &&
+                  (firewallDrawer.draftCIDRs.includes(`${clientIP}/32`) ||
+                    firewallDrawer.draftCIDRs.includes(clientIP)) && (
+                    <Text type="success" style={{ fontSize: 12 }}>
+                      ✓ {tr('已添加', 'Added')}
+                    </Text>
+                  )}
               </div>
             </div>
 
@@ -797,7 +1013,8 @@ const ProxyPage: React.FC = () => {
                     title: tr('协议', 'Protocol'),
                     width: 90,
                     render: () => {
-                      const at = firewallDrawer.record?.application?.application_type;
+                      const at =
+                        firewallDrawer.record?.application?.application_type;
                       const isHTTP = at === 'http';
                       return (
                         <Tag color={isHTTP ? 'green' : 'blue'} bordered={false}>
@@ -809,7 +1026,11 @@ const ProxyPage: React.FC = () => {
                   {
                     title: tr('端口', 'Port'),
                     width: 90,
-                    render: () => <Tag bordered={false}>{firewallDrawer.record?.port || '-'}</Tag>,
+                    render: () => (
+                      <Tag bordered={false}>
+                        {firewallDrawer.record?.port || '-'}
+                      </Tag>
+                    ),
                   },
                   {
                     title: tr('策略', 'Policy'),

--- a/web/src/typings.d.ts
+++ b/web/src/typings.d.ts
@@ -179,6 +179,13 @@ declare namespace API {
     description?: string;
     port: number;
     status: string;
+    effective_status?:
+      | 'active'
+      | 'stopped'
+      | 'edge_stopped'
+      | 'edge_offline'
+      | 'invalid';
+    effective_status_message?: string;
     application?: Application;
     created_at: string;
     updated_at: string;


### PR DESCRIPTION
## Summary

- separate proxy desired status from effective availability and surface effective status in API/UI
- make Edge stop a management-disabled state without mutating proxy desired status
- add lifecycle reconciliation, cascade cleanup, proxy listener restore rules, and Frontier control-plane disconnect support
- tighten Edge-bound RPC authentication and asset ownership checks for device/task/OOB flows
- update deployment templates to expose Frontier control-plane configuration

## Validation

- `git diff --check`
- `go test ./api/... ./cmd/... ./docs/... ./pkg/... ./tools/...`
- `./node_modules/.bin/max build`
