### PR TITLE
fix validation error responses

### DIFF
--- a/pkg/liaison/manager/controlplane/application.go
+++ b/pkg/liaison/manager/controlplane/application.go
@@ -2,6 +2,8 @@ package controlplane
 
 import (
 	"context"
+	"net"
+	"strings"
 	"time"
 
 	v1 "github.com/liaisonio/liaison/api/v1"
@@ -46,10 +48,21 @@ func detectApplicationTypeByPort(port int) string {
 }
 
 func (cp *controlPlane) CreateApplication(_ context.Context, req *v1.CreateApplicationRequest) (*v1.CreateApplicationResponse, error) {
+	name := strings.TrimSpace(req.Name)
+	ip := strings.TrimSpace(req.Ip)
+	if name == "" {
+		return nil, badRequest("APPLICATION_NAME_REQUIRED", "应用名称不能为空")
+	}
+	if !isValidApplicationHost(ip) {
+		return nil, badRequest("APPLICATION_IP_INVALID", "请输入合法的应用 IPv4、localhost 或主机名")
+	}
+	if req.EdgeId == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器不能为空")
+	}
 	// 验证 edge 是否存在
 	_, err := cp.repo.GetEdge(req.EdgeId)
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "连接器不存在")
 	}
 
 	// 根据应用的 IP 地址查找对应的 Device
@@ -57,9 +70,12 @@ func (cp *controlPlane) CreateApplication(_ context.Context, req *v1.CreateAppli
 	if req.DeviceId != nil && *req.DeviceId > 0 {
 		// 如果请求中指定了 device_id，优先使用
 		deviceID = uint(*req.DeviceId)
-	} else if req.Ip != "" {
+		if _, err := cp.repo.GetDeviceByID(deviceID); err != nil {
+			return nil, mapRecordNotFound(err, "DEVICE_NOT_FOUND", "设备不存在")
+		}
+	} else if ip != "" {
 		// 如果 IP 是 127.0.0.1，使用 edge 所在的 device
-		if req.Ip == "127.0.0.1" || req.Ip == "::1" || req.Ip == "localhost" {
+		if ip == "127.0.0.1" || ip == "::1" || strings.EqualFold(ip, "localhost") {
 			// 获取 edge 所在的 device（通过 EdgeDevice 关系表，类型为 Host）
 			hostType := model.EdgeDeviceRelationHost
 			edgeDevices, err := cp.repo.GetEdgeDevicesByEdgeID(req.EdgeId, &hostType)
@@ -68,17 +84,22 @@ func (cp *controlPlane) CreateApplication(_ context.Context, req *v1.CreateAppli
 			}
 		} else {
 			// 根据 IP 查找 Device
-			device, err := cp.repo.GetDeviceByIP(req.Ip)
+			device, err := cp.repo.GetDeviceByIP(ip)
 			if err == nil && device != nil {
 				deviceID = uint(device.ID)
+			} else if err != nil && !isRecordNotFound(err) {
+				return nil, err
 			}
 			// 如果根据 IP 找不到 Device，deviceID 保持为 0
 		}
 	}
 
 	// 处理应用类型和端口
-	appType := req.ApplicationType
+	appType := strings.ToLower(strings.TrimSpace(req.ApplicationType))
 	port := int(req.Port)
+	if port < 0 || port > 65535 {
+		return nil, badRequest("APPLICATION_PORT_INVALID", "应用端口必须在 1-65535 之间")
+	}
 
 	// 如果用户已经指定了应用类型，保持用户的选择，不根据端口推断
 	// 只有当应用类型为空（未指定）时，才根据端口号推断应用类型
@@ -98,12 +119,18 @@ func (cp *controlPlane) CreateApplication(_ context.Context, req *v1.CreateAppli
 	if appType == "" {
 		appType = "tcp"
 	}
+	if !isAllowedApplicationType(appType) {
+		return nil, badRequest("APPLICATION_TYPE_INVALID", "应用类型无效")
+	}
+	if port < 1 || port > 65535 {
+		return nil, badRequest("APPLICATION_PORT_INVALID", "应用端口必须在 1-65535 之间")
+	}
 
 	// 注意如果edge id不在线，应用可能无法访问
 	application := &model.Application{
-		Name:            req.Name,
+		Name:            name,
 		Description:     req.Description,
-		IP:              req.Ip,
+		IP:              ip,
 		Port:            port,
 		ApplicationType: model.ApplicationType(appType),
 		EdgeIDs:         model.UintSlice{uint(req.EdgeId)},
@@ -284,12 +311,19 @@ func (cp *controlPlane) ListApplications(_ context.Context, req *v1.ListApplicat
 }
 
 func (cp *controlPlane) UpdateApplication(_ context.Context, req *v1.UpdateApplicationRequest) (*v1.UpdateApplicationResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("APPLICATION_ID_REQUIRED", "应用 ID 不能为空")
+	}
 	application, err := cp.repo.GetApplicationByID(uint(req.Id))
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "APPLICATION_NOT_FOUND", "应用不存在")
 	}
 	if req.Name != "" {
-		application.Name = req.Name
+		name := strings.TrimSpace(req.Name)
+		if name == "" {
+			return nil, badRequest("APPLICATION_NAME_REQUIRED", "应用名称不能为空")
+		}
+		application.Name = name
 	}
 	if req.Description != "" {
 		application.Description = req.Description
@@ -311,6 +345,12 @@ func (cp *controlPlane) UpdateApplication(_ context.Context, req *v1.UpdateAppli
 }
 
 func (cp *controlPlane) DeleteApplication(_ context.Context, req *v1.DeleteApplicationRequest) (*v1.DeleteApplicationResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("APPLICATION_ID_REQUIRED", "应用 ID 不能为空")
+	}
+	if _, err := cp.repo.GetApplicationByID(uint(req.Id)); err != nil {
+		return nil, mapRecordNotFound(err, "APPLICATION_NOT_FOUND", "应用不存在")
+	}
 	if err := cp.deleteApplicationCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
@@ -318,6 +358,68 @@ func (cp *controlPlane) DeleteApplication(_ context.Context, req *v1.DeleteAppli
 		Code:    200,
 		Message: "success",
 	}, nil
+}
+
+func isAllowedApplicationType(appType string) bool {
+	switch appType {
+	case "http", "tcp", "ssh", "rdp", "mysql", "postgresql", "redis", "mongodb", "database":
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidApplicationHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" || strings.ContainsAny(host, "/ ") {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.To4() != nil
+	}
+	if looksLikeIPv4(host) {
+		return false
+	}
+	if len(host) > 253 {
+		return false
+	}
+	labels := strings.Split(host, ".")
+	for _, label := range labels {
+		if label == "" || len(label) > 63 {
+			return false
+		}
+		for i, r := range label {
+			valid := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-'
+			if !valid {
+				return false
+			}
+			if (i == 0 || i == len(label)-1) && r == '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func looksLikeIPv4(host string) bool {
+	labels := strings.Split(host, ".")
+	if len(labels) != 4 {
+		return false
+	}
+	for _, label := range labels {
+		if label == "" {
+			return false
+		}
+		for _, r := range label {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func transformApplications(applications []*model.Application) []*v1.Application {

--- a/pkg/liaison/manager/controlplane/device.go
+++ b/pkg/liaison/manager/controlplane/device.go
@@ -48,9 +48,12 @@ func (cp *controlPlane) ListDevices(_ context.Context, req *v1.ListDevicesReques
 }
 
 func (cp *controlPlane) GetDevice(_ context.Context, req *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("DEVICE_ID_REQUIRED", "设备 ID 不能为空")
+	}
 	device, err := cp.repo.GetDeviceByID(uint(req.Id))
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "DEVICE_NOT_FOUND", "设备不存在")
 	}
 	// 获取网卡
 	interfaces, err := cp.repo.GetEthernetInterfacesByDeviceID(uint(device.ID))
@@ -68,11 +71,17 @@ func (cp *controlPlane) GetDevice(_ context.Context, req *v1.GetDeviceRequest) (
 }
 
 func (cp *controlPlane) UpdateDevice(_ context.Context, req *v1.UpdateDeviceRequest) (*v1.UpdateDeviceResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("DEVICE_ID_REQUIRED", "设备 ID 不能为空")
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return nil, badRequest("DEVICE_NAME_REQUIRED", "设备名称不能为空")
+	}
 	device, err := cp.repo.GetDeviceByID(uint(req.Id))
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "DEVICE_NOT_FOUND", "设备不存在")
 	}
-	device.Name = req.Name
+	device.Name = strings.TrimSpace(req.Name)
 	device.Description = req.Description
 	err = cp.repo.UpdateDevice(device)
 	if err != nil {
@@ -85,6 +94,12 @@ func (cp *controlPlane) UpdateDevice(_ context.Context, req *v1.UpdateDeviceRequ
 }
 
 func (cp *controlPlane) DeleteDevice(_ context.Context, req *v1.DeleteDeviceRequest) (*v1.DeleteDeviceResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("DEVICE_ID_REQUIRED", "设备 ID 不能为空")
+	}
+	if _, err := cp.repo.GetDeviceByID(uint(req.Id)); err != nil {
+		return nil, mapRecordNotFound(err, "DEVICE_NOT_FOUND", "设备不存在")
+	}
 	if err := cp.deleteDeviceCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}

--- a/pkg/liaison/manager/controlplane/edge.go
+++ b/pkg/liaison/manager/controlplane/edge.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -19,11 +18,15 @@ import (
 )
 
 func (cp *controlPlane) CreateEdge(_ context.Context, req *v1.CreateEdgeRequest) (*v1.CreateEdgeResponse, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, badRequest("EDGE_NAME_REQUIRED", "连接器名称不能为空")
+	}
 	// 在事务中创建edge和ak/sk
 	tx := cp.repo.Begin()
 
 	edge := &model.Edge{
-		Name:        req.Name,
+		Name:        name,
 		Description: req.Description,
 		Status:      model.EdgeStatusRunning, // 默认状态为运行中
 		Online:      model.EdgeOnlineStatusOffline,
@@ -107,9 +110,12 @@ func (cp *controlPlane) CreateEdge(_ context.Context, req *v1.CreateEdgeRequest)
 }
 
 func (cp *controlPlane) GetEdge(_ context.Context, req *v1.GetEdgeRequest) (*v1.GetEdgeResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器 ID 不能为空")
+	}
 	edge, err := cp.repo.GetEdge(req.Id)
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "连接器不存在")
 	}
 	// 通过 EdgeDevice 关系表获取关联的 Device（Host 类型）
 	hostType := model.EdgeDeviceRelationHost
@@ -279,13 +285,20 @@ func (cp *controlPlane) ListEdges(_ context.Context, req *v1.ListEdgesRequest) (
 }
 
 func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest) (*v1.UpdateEdgeResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器 ID 不能为空")
+	}
 	edge, err := cp.repo.GetEdge(req.Id)
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "连接器不存在")
 	}
 	oldStatus := edge.Status
 	if req.Name != "" {
-		edge.Name = req.Name
+		name := strings.TrimSpace(req.Name)
+		if name == "" {
+			return nil, badRequest("EDGE_NAME_REQUIRED", "连接器名称不能为空")
+		}
+		edge.Name = name
 	}
 	if req.Description != "" {
 		edge.Description = req.Description
@@ -295,7 +308,7 @@ func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest)
 		case model.EdgeStatusRunning, model.EdgeStatusStopped:
 			edge.Status = model.EdgeStatus(req.Status)
 		default:
-			return nil, fmt.Errorf("unknown edge status: %d", req.Status)
+			return nil, badRequest("EDGE_STATUS_INVALID", "连接器运行状态无效")
 		}
 	}
 	statusChanged := oldStatus != edge.Status
@@ -331,6 +344,12 @@ func (cp *controlPlane) UpdateEdge(_ context.Context, req *v1.UpdateEdgeRequest)
 }
 
 func (cp *controlPlane) DeleteEdge(_ context.Context, req *v1.DeleteEdgeRequest) (*v1.DeleteEdgeResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器 ID 不能为空")
+	}
+	if _, err := cp.repo.GetEdge(req.Id); err != nil {
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "连接器不存在")
+	}
 	if err := cp.deleteEdgeCascade(req.Id, newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}
@@ -341,19 +360,32 @@ func (cp *controlPlane) DeleteEdge(_ context.Context, req *v1.DeleteEdgeRequest)
 }
 
 func (cp *controlPlane) CreateEdgeScanApplicationTask(_ context.Context, req *v1.CreateEdgeScanApplicationTaskRequest) (*v1.CreateEdgeScanApplicationTaskResponse, error) {
+	if req.EdgeId == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器 ID 不能为空")
+	}
+	if req.Port < 0 || req.Port > 65535 {
+		return nil, badRequest("SCAN_PORT_INVALID", "扫描端口必须在 1-65535 之间，或留空扫描常用端口")
+	}
+	req.Protocol = strings.ToLower(strings.TrimSpace(req.Protocol))
+	if req.Protocol == "" {
+		req.Protocol = "tcp"
+	}
+	if req.Protocol != "tcp" && req.Protocol != "udp" {
+		return nil, badRequest("SCAN_PROTOCOL_INVALID", "扫描协议仅支持 tcp 或 udp")
+	}
 	// 获取edge
 	edge, err := cp.repo.GetEdge(req.EdgeId)
 	if err != nil {
 		log.Errorf("get edge error: %s", err)
-		return nil, err
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "连接器不存在")
 	}
 	if edge.Status == model.EdgeStatusStopped {
 		log.Errorf("edge is stopped")
-		return nil, errors.New("edge is stopped")
+		return nil, preconditionFailed("EDGE_STOPPED", "连接器已禁用，无法扫描应用")
 	}
 	if edge.Online != model.EdgeOnlineStatusOnline {
 		log.Errorf("edge is not online")
-		return nil, errors.New("edge is not online")
+		return nil, preconditionFailed("EDGE_OFFLINE", "连接器离线，无法扫描应用")
 	}
 
 	// 获取设备（通过 EdgeDevice 关系表，Host 类型）
@@ -361,12 +393,12 @@ func (cp *controlPlane) CreateEdgeScanApplicationTask(_ context.Context, req *v1
 	edgeDevices, err := cp.repo.GetEdgeDevicesByEdgeID(req.EdgeId, &hostType)
 	if err != nil || len(edgeDevices) == 0 {
 		log.Errorf("get edge device relation error: %s", err)
-		return nil, errors.New("edge has no associated device")
+		return nil, conflict("EDGE_DEVICE_MISSING", "连接器未关联设备，无法扫描应用")
 	}
 	device, err := cp.repo.GetDeviceByID(edgeDevices[0].DeviceID)
 	if err != nil {
 		log.Errorf("get device error: %s", err)
-		return nil, err
+		return nil, mapRecordNotFound(err, "DEVICE_NOT_FOUND", "连接器关联设备不存在")
 	}
 	nets := []string{}
 	for _, iface := range device.Interfaces {
@@ -447,6 +479,9 @@ func (cp *controlPlane) CreateEdgeScanApplicationTask(_ context.Context, req *v1
 }
 
 func (cp *controlPlane) GetEdgeScanApplicationTask(_ context.Context, req *v1.GetEdgeScanApplicationTaskRequest) (*v1.GetEdgeScanApplicationTaskResponse, error) {
+	if req.EdgeId == 0 {
+		return nil, badRequest("EDGE_ID_REQUIRED", "连接器 ID 不能为空")
+	}
 	tasks, err := cp.repo.ListTasks(&dao.ListTasksQuery{
 		EdgeID:      uint(req.EdgeId),
 		TaskType:    model.TaskTypeScan,

--- a/pkg/liaison/manager/controlplane/errors.go
+++ b/pkg/liaison/manager/controlplane/errors.go
@@ -1,6 +1,12 @@
 package controlplane
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"gorm.io/gorm"
+)
 
 // errForbidden is returned when a request targets a resource owned by
 // another user. HTTP handlers map this to 403.
@@ -9,3 +15,77 @@ var errForbidden = errors.New("forbidden")
 // ErrForbidden returns the sentinel used for cross-user access denials, for
 // callers outside this package that need errors.Is matching.
 func ErrForbidden() error { return errForbidden }
+
+// HTTPError marks an expected control-plane failure that should be rendered as
+// a concrete client-facing HTTP status instead of falling through as 500.
+type HTTPError struct {
+	status  int
+	reason  string
+	message string
+	cause   error
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %v", e.message, e.cause)
+	}
+	return e.message
+}
+
+func (e *HTTPError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *HTTPError) Status() int {
+	if e == nil || e.status == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.status
+}
+
+func (e *HTTPError) Reason() string {
+	if e == nil || e.reason == "" {
+		return "CONTROL_PLANE_ERROR"
+	}
+	return e.reason
+}
+
+func (e *HTTPError) Message() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+func badRequest(reason, message string) error {
+	return &HTTPError{status: http.StatusBadRequest, reason: reason, message: message}
+}
+
+func notFound(reason, message string, cause error) error {
+	return &HTTPError{status: http.StatusNotFound, reason: reason, message: message, cause: cause}
+}
+
+func conflict(reason, message string) error {
+	return &HTTPError{status: http.StatusConflict, reason: reason, message: message}
+}
+
+func preconditionFailed(reason, message string) error {
+	return &HTTPError{status: http.StatusPreconditionFailed, reason: reason, message: message}
+}
+
+func isRecordNotFound(err error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
+}
+
+func mapRecordNotFound(err error, reason, message string) error {
+	if isRecordNotFound(err) {
+		return notFound(reason, message, err)
+	}
+	return err
+}

--- a/pkg/liaison/manager/controlplane/firewall.go
+++ b/pkg/liaison/manager/controlplane/firewall.go
@@ -103,10 +103,10 @@ func (cp *controlPlane) DeleteProxyFirewall(ctx context.Context, proxyID uint) e
 func (cp *controlPlane) getProxyForFirewall(proxyID uint) (*model.Proxy, error) {
 	proxy, err := cp.repo.GetProxyByID(proxyID)
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "PROXY_NOT_FOUND", "访问不存在")
 	}
 	if proxy == nil {
-		return nil, fmt.Errorf("proxy not found")
+		return nil, notFound("PROXY_NOT_FOUND", "访问不存在", nil)
 	}
 	return proxy, nil
 }

--- a/pkg/liaison/manager/controlplane/lifecycle.go
+++ b/pkg/liaison/manager/controlplane/lifecycle.go
@@ -237,37 +237,37 @@ func (cp *controlPlane) proxyRuntimeEligible(proxy *model.Proxy, application *mo
 		return false, nil
 	}
 	if application == nil {
-		return false, errors.New("proxy application is missing")
+		return false, notFound("APPLICATION_NOT_FOUND", "关联应用不存在", nil)
 	}
 	if len(application.EdgeIDs) == 0 {
-		return false, errors.New("application has no edge")
+		return false, conflict("APPLICATION_EDGE_MISSING", "关联应用未绑定连接器")
 	}
 	edge, err := cp.repo.GetEdge(uint64(application.EdgeIDs[0]))
 	if err != nil {
-		return false, fmt.Errorf("application edge %d is missing: %w", application.EdgeIDs[0], err)
+		return false, mapRecordNotFound(err, "EDGE_NOT_FOUND", "关联连接器不存在")
 	}
 	if edge.Status == model.EdgeStatusStopped {
 		return false, nil
 	}
 	if edge.Status != model.EdgeStatusRunning {
-		return false, fmt.Errorf("unknown edge status %d", edge.Status)
+		return false, conflict("EDGE_STATUS_INVALID", "连接器状态无效")
 	}
 	return true, nil
 }
 
 func (cp *controlPlane) validateProxyApplication(application *model.Application) (*model.Edge, error) {
 	if application == nil {
-		return nil, errors.New("application is missing")
+		return nil, notFound("APPLICATION_NOT_FOUND", "关联应用不存在", nil)
 	}
 	if len(application.EdgeIDs) == 0 {
-		return nil, errors.New("application has no edge")
+		return nil, conflict("APPLICATION_EDGE_MISSING", "关联应用未绑定连接器")
 	}
 	edge, err := cp.repo.GetEdge(uint64(application.EdgeIDs[0]))
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "EDGE_NOT_FOUND", "关联连接器不存在")
 	}
 	if edge.Status != model.EdgeStatusRunning && edge.Status != model.EdgeStatusStopped {
-		return nil, fmt.Errorf("unknown edge status %d", edge.Status)
+		return nil, conflict("EDGE_STATUS_INVALID", "连接器状态无效")
 	}
 	return edge, nil
 }
@@ -304,9 +304,16 @@ func (cp *controlPlane) ensureProxyPortAvailable(port int, excludeProxyID uint) 
 		return err
 	}
 	if conflict != nil {
-		return fmt.Errorf("public port %d is already used by proxy %d", port, conflict.ID)
+		return conflictErrorForProxyPort(port, conflict.ID)
 	}
 	return nil
+}
+
+func conflictErrorForProxyPort(port int, proxyID uint) error {
+	return conflict(
+		"PROXY_PORT_CONFLICT",
+		fmt.Sprintf("公网端口 %d 已被访问 %d 使用", port, proxyID),
+	)
 }
 
 func (cp *controlPlane) findProxyPortConflict(port int, excludeProxyID uint) (*model.Proxy, error) {

--- a/pkg/liaison/manager/controlplane/proxy.go
+++ b/pkg/liaison/manager/controlplane/proxy.go
@@ -23,10 +23,20 @@ func (cp *controlPlane) RegisterFirewallManager(firewallManager proto.FirewallMa
 }
 
 func (cp *controlPlane) CreateProxy(_ context.Context, req *v1.CreateProxyRequest) (*v1.CreateProxyResponse, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, badRequest("PROXY_NAME_REQUIRED", "访问名称不能为空")
+	}
+	if req.ApplicationId == 0 {
+		return nil, badRequest("APPLICATION_ID_REQUIRED", "关联应用不能为空")
+	}
+	if req.Port < 0 || req.Port > 65535 {
+		return nil, badRequest("PROXY_PORT_INVALID", "公网端口必须在 1-65535 之间，或留空自动分配")
+	}
 	application, err := cp.repo.GetApplicationByID(uint(req.ApplicationId))
 	if err != nil {
 		log.Warnf("application %d not found", req.ApplicationId)
-		return nil, err
+		return nil, mapRecordNotFound(err, "APPLICATION_NOT_FOUND", "关联应用不存在")
 	}
 	edge, err := cp.validateProxyApplication(application)
 	if err != nil {
@@ -46,7 +56,7 @@ func (cp *controlPlane) CreateProxy(_ context.Context, req *v1.CreateProxyReques
 	}
 
 	proxy := &model.Proxy{
-		Name:          req.Name,
+		Name:          name,
 		Status:        model.ProxyStatusRunning,
 		Description:   req.Description,
 		Port:          requestedPort,
@@ -150,15 +160,25 @@ func (cp *controlPlane) ListProxies(_ context.Context, req *v1.ListProxiesReques
 }
 
 func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyRequest) (*v1.UpdateProxyResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("PROXY_ID_REQUIRED", "访问 ID 不能为空")
+	}
+	if req.Port < 0 || req.Port > 65535 {
+		return nil, badRequest("PROXY_PORT_INVALID", "公网端口必须在 1-65535 之间")
+	}
 	proxy, err := cp.repo.GetProxyByID(uint(req.Id))
 	if err != nil {
-		return nil, err
+		return nil, mapRecordNotFound(err, "PROXY_NOT_FOUND", "访问不存在")
 	}
 
 	oldProxy := *proxy
 
 	if req.Name != "" {
-		proxy.Name = req.Name
+		name := strings.TrimSpace(req.Name)
+		if name == "" {
+			return nil, badRequest("PROXY_NAME_REQUIRED", "访问名称不能为空")
+		}
+		proxy.Name = name
 	}
 	if req.Description != "" {
 		proxy.Description = req.Description
@@ -176,7 +196,7 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 		case "stopped":
 			proxy.Status = model.ProxyStatusStopped
 		default:
-			return nil, fmt.Errorf("unknown proxy status: %s", req.Status)
+			return nil, badRequest("PROXY_STATUS_INVALID", "访问状态无效")
 		}
 	}
 
@@ -190,7 +210,7 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 		application, applicationErr = cp.repo.GetApplicationByID(proxy.ApplicationID)
 	}
 	if proxy.Status == model.ProxyStatusRunning && applicationErr != nil {
-		return nil, applicationErr
+		return nil, mapRecordNotFound(applicationErr, "APPLICATION_NOT_FOUND", "关联应用不存在")
 	}
 
 	oldRuntimeEligible := false
@@ -253,6 +273,12 @@ func (cp *controlPlane) UpdateProxy(_ context.Context, req *v1.UpdateProxyReques
 }
 
 func (cp *controlPlane) DeleteProxy(_ context.Context, req *v1.DeleteProxyRequest) (*v1.DeleteProxyResponse, error) {
+	if req.Id == 0 {
+		return nil, badRequest("PROXY_ID_REQUIRED", "访问 ID 不能为空")
+	}
+	if _, err := cp.repo.GetProxyByID(uint(req.Id)); err != nil {
+		return nil, mapRecordNotFound(err, "PROXY_NOT_FOUND", "访问不存在")
+	}
 	if err := cp.deleteProxyCascade(uint(req.Id), newLifecycleDeleteTracker()); err != nil {
 		return nil, err
 	}

--- a/pkg/liaison/manager/controlplane/traffic.go
+++ b/pkg/liaison/manager/controlplane/traffic.go
@@ -15,6 +15,9 @@ import (
 const localTimeFormat = "2006-01-02T15:04:05"
 
 func (cp *controlPlane) ListTrafficMetrics(_ context.Context, req *v1.ListTrafficMetricsRequest) (*v1.ListTrafficMetricsResponse, error) {
+	if req.Limit < 0 || req.Limit > 10000 {
+		return nil, badRequest("TRAFFIC_LIMIT_INVALID", "流量查询 limit 必须在 0-10000 之间")
+	}
 	query := &dao.ListTrafficMetricsQuery{
 		Limit: int(req.Limit),
 	}
@@ -37,26 +40,21 @@ func (cp *controlPlane) ListTrafficMetrics(_ context.Context, req *v1.ListTraffi
 
 	// 解析时间范围（前端发送的是本地时间或RFC3339格式）
 	if req.StartTime != "" {
-		// 尝试解析RFC3339格式，如果失败则尝试本地时间格式
-		startTime, err := time.Parse(time.RFC3339, req.StartTime)
+		startTime, err := parseTrafficTime(req.StartTime)
 		if err != nil {
-			startTime, err = time.Parse(localTimeFormat, req.StartTime)
+			return nil, badRequest("TRAFFIC_START_TIME_INVALID", "开始时间格式无效")
 		}
-		if err == nil {
-			// 使用本地时间用于查询
-			query.StartTime = &startTime
-		}
+		query.StartTime = &startTime
 	}
 	if req.EndTime != "" {
-		// 尝试解析RFC3339格式，如果失败则尝试本地时间格式
-		endTime, err := time.Parse(time.RFC3339, req.EndTime)
+		endTime, err := parseTrafficTime(req.EndTime)
 		if err != nil {
-			endTime, err = time.Parse(localTimeFormat, req.EndTime)
+			return nil, badRequest("TRAFFIC_END_TIME_INVALID", "结束时间格式无效")
 		}
-		if err == nil {
-			// 使用本地时间用于查询
-			query.EndTime = &endTime
-		}
+		query.EndTime = &endTime
+	}
+	if query.StartTime != nil && query.EndTime != nil && query.StartTime.After(*query.EndTime) {
+		return nil, badRequest("TRAFFIC_TIME_RANGE_INVALID", "开始时间不能晚于结束时间")
 	}
 
 	// 如果没有设置 limit，根据时间范围计算合理的limit
@@ -183,4 +181,12 @@ func (cp *controlPlane) ListTrafficMetrics(_ context.Context, req *v1.ListTraffi
 			Metrics: metricsV1,
 		},
 	}, nil
+}
+
+func parseTrafficTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		return parsed, nil
+	}
+	return time.Parse(localTimeFormat, value)
 }

--- a/pkg/liaison/manager/web/firewall_http.go
+++ b/pkg/liaison/manager/web/firewall_http.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/liaisonio/liaison/pkg/liaison/manager/controlplane"
 )
 
 // upsertFirewallRequest is the body of PUT /api/v1/proxies/{id}/firewall.
@@ -116,6 +118,10 @@ func parseFirewallProxyID(r *http.Request) (uint, error) {
 }
 
 func firewallHTTPStatus(err error) int {
+	var httpErr *controlplane.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Status()
+	}
 	// Only ErrForbidden is mapped to 403 for now; everything else is a bad
 	// request (invalid CIDR, missing proxy, etc.).
 	if errors.Is(err, errUnauthorized) {

--- a/pkg/liaison/manager/web/handler.go
+++ b/pkg/liaison/manager/web/handler.go
@@ -10,8 +10,23 @@ import (
 	kratoserrors "github.com/go-kratos/kratos/v2/errors"
 	kratoshttp "github.com/go-kratos/kratos/v2/transport/http"
 	v1 "github.com/liaisonio/liaison/api/v1"
+	"github.com/liaisonio/liaison/pkg/liaison/manager/controlplane"
 	"github.com/liaisonio/liaison/pkg/liaison/manager/iam"
 )
+
+func mapServiceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var httpErr *controlplane.HTTPError
+	if errors.As(err, &httpErr) {
+		return kratoserrors.New(httpErr.Status(), httpErr.Reason(), httpErr.Message())
+	}
+	if errors.Is(err, controlplane.ErrForbidden()) {
+		return kratoserrors.New(403, "FORBIDDEN", "无权访问该资源")
+	}
+	return err
+}
 
 //-- Edge --//
 
@@ -21,7 +36,11 @@ import (
 // @Success 200 {object} v1.CreateEdgeResponse
 // @Router /api/v1/edges [post]
 func (web *web) CreateEdge(ctx context.Context, req *v1.CreateEdgeRequest) (*v1.CreateEdgeResponse, error) {
-	return web.controlPlane.CreateEdge(ctx, req)
+	resp, err := web.controlPlane.CreateEdge(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary GetEdge
@@ -31,7 +50,11 @@ func (web *web) CreateEdge(ctx context.Context, req *v1.CreateEdgeRequest) (*v1.
 // @Success 200 {object} v1.GetEdgeResponse
 // @Router /api/v1/edges/{id} [get]
 func (web *web) GetEdge(ctx context.Context, req *v1.GetEdgeRequest) (*v1.GetEdgeResponse, error) {
-	return web.controlPlane.GetEdge(ctx, req)
+	resp, err := web.controlPlane.GetEdge(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary ListEdges
@@ -40,7 +63,11 @@ func (web *web) GetEdge(ctx context.Context, req *v1.GetEdgeRequest) (*v1.GetEdg
 // @Success 200 {object} v1.ListEdgesResponse
 // @Router /api/v1/edges [get]
 func (web *web) ListEdges(ctx context.Context, req *v1.ListEdgesRequest) (*v1.ListEdgesResponse, error) {
-	return web.controlPlane.ListEdges(ctx, req)
+	resp, err := web.controlPlane.ListEdges(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary UpdateEdge
@@ -50,7 +77,11 @@ func (web *web) ListEdges(ctx context.Context, req *v1.ListEdgesRequest) (*v1.Li
 // @Success 200 {object} v1.UpdateEdgeResponse
 // @Router /api/v1/edges/{id} [put]
 func (web *web) UpdateEdge(ctx context.Context, req *v1.UpdateEdgeRequest) (*v1.UpdateEdgeResponse, error) {
-	return web.controlPlane.UpdateEdge(ctx, req)
+	resp, err := web.controlPlane.UpdateEdge(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary DeleteEdge
@@ -59,7 +90,11 @@ func (web *web) UpdateEdge(ctx context.Context, req *v1.UpdateEdgeRequest) (*v1.
 // @Success 200 {object} v1.DeleteEdgeResponse
 // @Router /api/v1/edges/{id} [delete]
 func (web *web) DeleteEdge(ctx context.Context, req *v1.DeleteEdgeRequest) (*v1.DeleteEdgeResponse, error) {
-	return web.controlPlane.DeleteEdge(ctx, req)
+	resp, err := web.controlPlane.DeleteEdge(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Device --//
@@ -70,7 +105,11 @@ func (web *web) DeleteEdge(ctx context.Context, req *v1.DeleteEdgeRequest) (*v1.
 // @Success 200 {object} v1.ListDevicesResponse
 // @Router /api/v1/devices [get]
 func (web *web) ListDevices(ctx context.Context, req *v1.ListDevicesRequest) (*v1.ListDevicesResponse, error) {
-	return web.controlPlane.ListDevices(ctx, req)
+	resp, err := web.controlPlane.ListDevices(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary GetDevice
@@ -80,7 +119,11 @@ func (web *web) ListDevices(ctx context.Context, req *v1.ListDevicesRequest) (*v
 // @Success 200 {object} v1.GetDeviceResponse
 // @Router /api/v1/devices/{id} [get]
 func (web *web) GetDevice(ctx context.Context, req *v1.GetDeviceRequest) (*v1.GetDeviceResponse, error) {
-	return web.controlPlane.GetDevice(ctx, req)
+	resp, err := web.controlPlane.GetDevice(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary UpdateDevice
@@ -90,7 +133,11 @@ func (web *web) GetDevice(ctx context.Context, req *v1.GetDeviceRequest) (*v1.Ge
 // @Success 200 {object} v1.UpdateDeviceResponse
 // @Router /api/v1/devices/{id} [put]
 func (web *web) UpdateDevice(ctx context.Context, req *v1.UpdateDeviceRequest) (*v1.UpdateDeviceResponse, error) {
-	return web.controlPlane.UpdateDevice(ctx, req)
+	resp, err := web.controlPlane.UpdateDevice(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary DeleteDevice
@@ -99,7 +146,11 @@ func (web *web) UpdateDevice(ctx context.Context, req *v1.UpdateDeviceRequest) (
 // @Success 200 {object} v1.DeleteDeviceResponse
 // @Router /api/v1/devices/{id} [delete]
 func (web *web) DeleteDevice(ctx context.Context, req *v1.DeleteDeviceRequest) (*v1.DeleteDeviceResponse, error) {
-	return web.controlPlane.DeleteDevice(ctx, req)
+	resp, err := web.controlPlane.DeleteDevice(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Application --//
@@ -110,7 +161,11 @@ func (web *web) DeleteDevice(ctx context.Context, req *v1.DeleteDeviceRequest) (
 // @Success 200 {object} v1.CreateApplicationResponse
 // @Router /api/v1/applications [post]
 func (web *web) CreateApplication(ctx context.Context, req *v1.CreateApplicationRequest) (*v1.CreateApplicationResponse, error) {
-	return web.controlPlane.CreateApplication(ctx, req)
+	resp, err := web.controlPlane.CreateApplication(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary ListApplications
@@ -119,7 +174,11 @@ func (web *web) CreateApplication(ctx context.Context, req *v1.CreateApplication
 // @Success 200 {object} v1.ListApplicationsResponse
 // @Router /api/v1/applications [get]
 func (web *web) ListApplications(ctx context.Context, req *v1.ListApplicationsRequest) (*v1.ListApplicationsResponse, error) {
-	return web.controlPlane.ListApplications(ctx, req)
+	resp, err := web.controlPlane.ListApplications(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary UpdateApplication
@@ -129,7 +188,11 @@ func (web *web) ListApplications(ctx context.Context, req *v1.ListApplicationsRe
 // @Success 200 {object} v1.UpdateApplicationResponse
 // @Router /api/v1/applications/{id} [put]
 func (web *web) UpdateApplication(ctx context.Context, req *v1.UpdateApplicationRequest) (*v1.UpdateApplicationResponse, error) {
-	return web.controlPlane.UpdateApplication(ctx, req)
+	resp, err := web.controlPlane.UpdateApplication(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary DeleteApplication
@@ -138,7 +201,11 @@ func (web *web) UpdateApplication(ctx context.Context, req *v1.UpdateApplication
 // @Success 200 {object} v1.DeleteApplicationResponse
 // @Router /api/v1/applications/{id} [delete]
 func (web *web) DeleteApplication(ctx context.Context, req *v1.DeleteApplicationRequest) (*v1.DeleteApplicationResponse, error) {
-	return web.controlPlane.DeleteApplication(ctx, req)
+	resp, err := web.controlPlane.DeleteApplication(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Proxy --//
@@ -149,7 +216,11 @@ func (web *web) DeleteApplication(ctx context.Context, req *v1.DeleteApplication
 // @Success 200 {object} v1.ListProxiesResponse
 // @Router /api/v1/proxies [get]
 func (web *web) ListProxies(ctx context.Context, req *v1.ListProxiesRequest) (*v1.ListProxiesResponse, error) {
-	return web.controlPlane.ListProxies(ctx, req)
+	resp, err := web.controlPlane.ListProxies(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary CreateProxy
@@ -158,7 +229,11 @@ func (web *web) ListProxies(ctx context.Context, req *v1.ListProxiesRequest) (*v
 // @Success 200 {object} v1.CreateProxyResponse
 // @Router /api/v1/proxies [post]
 func (web *web) CreateProxy(ctx context.Context, req *v1.CreateProxyRequest) (*v1.CreateProxyResponse, error) {
-	return web.controlPlane.CreateProxy(ctx, req)
+	resp, err := web.controlPlane.CreateProxy(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary UpdateProxy
@@ -168,7 +243,11 @@ func (web *web) CreateProxy(ctx context.Context, req *v1.CreateProxyRequest) (*v
 // @Success 200 {object} v1.UpdateProxyResponse
 // @Router /api/v1/proxies/{id} [put]
 func (web *web) UpdateProxy(ctx context.Context, req *v1.UpdateProxyRequest) (*v1.UpdateProxyResponse, error) {
-	return web.controlPlane.UpdateProxy(ctx, req)
+	resp, err := web.controlPlane.UpdateProxy(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary DeleteProxy
@@ -177,7 +256,11 @@ func (web *web) UpdateProxy(ctx context.Context, req *v1.UpdateProxyRequest) (*v
 // @Success 200 {object} v1.DeleteProxyResponse
 // @Router /api/v1/proxies/{id} [delete]
 func (web *web) DeleteProxy(ctx context.Context, req *v1.DeleteProxyRequest) (*v1.DeleteProxyResponse, error) {
-	return web.controlPlane.DeleteProxy(ctx, req)
+	resp, err := web.controlPlane.DeleteProxy(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Traffic Metric --//
@@ -188,7 +271,11 @@ func (web *web) DeleteProxy(ctx context.Context, req *v1.DeleteProxyRequest) (*v
 // @Success 200 {object} v1.ListTrafficMetricsResponse
 // @Router /api/v1/traffic-metrics [get]
 func (web *web) ListTrafficMetrics(ctx context.Context, req *v1.ListTrafficMetricsRequest) (*v1.ListTrafficMetricsResponse, error) {
-	return web.controlPlane.ListTrafficMetrics(ctx, req)
+	resp, err := web.controlPlane.ListTrafficMetrics(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Task --//
@@ -199,7 +286,11 @@ func (web *web) ListTrafficMetrics(ctx context.Context, req *v1.ListTrafficMetri
 // @Success 200 {object} v1.CreateEdgeScanApplicationTaskResponse
 // @Router /api/v1/edges/{edge_id}/scan_application_tasks [post]
 func (web *web) CreateEdgeScanApplicationTask(ctx context.Context, req *v1.CreateEdgeScanApplicationTaskRequest) (*v1.CreateEdgeScanApplicationTaskResponse, error) {
-	return web.controlPlane.CreateEdgeScanApplicationTask(ctx, req)
+	resp, err := web.controlPlane.CreateEdgeScanApplicationTask(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 // @Summary GetEdgeScanApplicationTask
@@ -208,7 +299,11 @@ func (web *web) CreateEdgeScanApplicationTask(ctx context.Context, req *v1.Creat
 // @Success 200 {object} v1.GetEdgeScanApplicationTaskResponse
 // @Router /api/v1/edges/{edge_id}/scan_application_tasks [get]
 func (web *web) GetEdgeScanApplicationTask(ctx context.Context, req *v1.GetEdgeScanApplicationTaskRequest) (*v1.GetEdgeScanApplicationTaskResponse, error) {
-	return web.controlPlane.GetEdgeScanApplicationTask(ctx, req)
+	resp, err := web.controlPlane.GetEdgeScanApplicationTask(ctx, req)
+	if err != nil {
+		return nil, mapServiceError(err)
+	}
+	return resp, nil
 }
 
 //-- Auth --//
@@ -382,6 +477,12 @@ func (web *web) ChangePassword(ctx context.Context, req *v1.ChangePasswordReques
 	// 调用IAM服务修改密码
 	err := web.iamService.ChangePassword(userID.(uint), iamReq)
 	if err != nil {
+		if err.Error() == "invalid old password" {
+			return nil, kratoserrors.New(400, "INVALID_OLD_PASSWORD", "当前密码错误")
+		}
+		if err.Error() == "user not found" {
+			return nil, kratoserrors.New(404, "USER_NOT_FOUND", "用户不存在")
+		}
 		return nil, err
 	}
 

--- a/web/src/pages/App/index.tsx
+++ b/web/src/pages/App/index.tsx
@@ -7,6 +7,7 @@ import {
   getApplicationList,
   getDeviceList,
   getEdgeList,
+  getProxyList,
   updateApplication,
 } from '@/services/api';
 import { executeAction, tableRequest } from '@/utils/request';
@@ -53,6 +54,71 @@ const AppPage: React.FC = () => {
 
   const reload = () => actionRef.current?.reload();
 
+  const isValidIPv4Address = (value: string): boolean => {
+    const parts = value.split('.');
+    if (parts.length !== 4) return false;
+    return parts.every((part) => {
+      if (!/^\d+$/.test(part)) return false;
+      if (part.length > 1 && part.startsWith('0')) return false;
+      const octet = Number(part);
+      return octet >= 0 && octet <= 255;
+    });
+  };
+
+  const isValidApplicationHost = (value: string): boolean => {
+    const host = value.trim();
+    if (
+      !host ||
+      host.length > 253 ||
+      host.includes('/') ||
+      host.includes(' ')
+    ) {
+      return false;
+    }
+    if (host.toLowerCase() === 'localhost') return true;
+    if (host.includes(':')) return false;
+    if (isValidIPv4Address(host)) return true;
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return false;
+    return host.split('.').every((label) => {
+      if (!label || label.length > 63) return false;
+      if (label.startsWith('-') || label.endsWith('-')) return false;
+      return /^[A-Za-z0-9-]+$/.test(label);
+    });
+  };
+
+  const validatePublicPort = async (value?: number) => {
+    if (value === undefined || value === null) return Promise.resolve();
+    if (!Number.isInteger(value) || value < 1 || value > 65535) {
+      return Promise.reject(
+        new Error(
+          tr(
+            '公网端口必须在1-65535之间',
+            'Public port must be between 1 and 65535',
+          ),
+        ),
+      );
+    }
+    try {
+      const res = await getProxyList({ page_size: 10000 });
+      const conflict = res.data?.proxies?.find(
+        (proxy: API.Proxy) => proxy.port === value,
+      );
+      if (conflict) {
+        return Promise.reject(
+          new Error(
+            tr(
+              `公网端口 ${value} 已被访问「${conflict.name}」使用`,
+              `Public port ${value} is already used by entry "${conflict.name}"`,
+            ),
+          ),
+        );
+      }
+    } catch {
+      // 后端仍会做最终冲突校验；列表预校验失败时不阻塞表单。
+    }
+    return Promise.resolve();
+  };
+
   // 加载设备列表
   const loadDeviceOptions = async () => {
     if (deviceOptions.length > 0) return; // 已加载过，不再重复加载
@@ -72,9 +138,9 @@ const AppPage: React.FC = () => {
     return executeAction(
       () =>
         createApplication({
-          name: values.name,
+          name: values.name?.trim(),
           application_type: values.application_type,
-          ip: values.ip,
+          ip: values.ip?.trim(),
           port: values.port,
           edge_id: values.edge_id,
           device_id: values.device_id,
@@ -121,7 +187,7 @@ const AppPage: React.FC = () => {
     const result = await executeAction(
       () =>
         createProxy({
-          name: values.name || currentRow.name,
+          name: values.name?.trim() || currentRow.name,
           description: values.description,
           port: createPort,
           application_id: currentRow.id,
@@ -452,6 +518,23 @@ const AppPage: React.FC = () => {
               required: true,
               message: tr('请输入 IP 地址', 'Please input IP address'),
             },
+            {
+              validator: (_: any, value?: string) => {
+                const trimmed = value?.trim();
+                if (!trimmed) return Promise.resolve();
+                if (!isValidApplicationHost(trimmed)) {
+                  return Promise.reject(
+                    new Error(
+                      tr(
+                        '请输入合法的 IPv4 地址、localhost 或主机名',
+                        'Please input a valid IPv4 address, localhost, or hostname',
+                      ),
+                    ),
+                  );
+                }
+                return Promise.resolve();
+              },
+            },
           ]}
         />
         <ProFormDigit
@@ -460,6 +543,7 @@ const AppPage: React.FC = () => {
           placeholder={tr('请输入端口号', 'Please input port')}
           min={1}
           max={65535}
+          fieldProps={{ precision: 0 }}
           rules={[
             {
               required: true,
@@ -606,6 +690,12 @@ const AppPage: React.FC = () => {
           placeholder={tr('留空自动分配', 'Leave empty for auto allocation')}
           min={1}
           max={65535}
+          fieldProps={{ precision: 0 }}
+          rules={[
+            {
+              validator: (_: any, value?: number) => validatePublicPort(value),
+            },
+          ]}
           extra={tr(
             '映射到公网的端口号，留空则自动分配',
             'Mapped public port, empty means auto allocation',

--- a/web/src/pages/Connector/index.tsx
+++ b/web/src/pages/Connector/index.tsx
@@ -49,6 +49,7 @@ import {
   Switch,
   Tabs,
   Tag,
+  Tooltip,
   Typography,
 } from 'antd';
 import { useRef, useState } from 'react';
@@ -134,23 +135,27 @@ const ConnectorPage: React.FC = () => {
     );
   };
 
-  const handleDiscoverApps = async (edge: API.Edge) => {
+  const getScanDisabledReason = (edge?: API.Edge) => {
+    if (!edge) return '';
     if (edge.status !== 1) {
-      message.warning(
-        tr(
-          '连接器已禁用，无法扫描应用',
-          'Edge is disabled, cannot scan applications',
-        ),
+      return tr(
+        '连接器已禁用，无法扫描应用',
+        'Edge is disabled, cannot scan applications',
       );
-      return;
     }
     if (edge.online !== 1) {
-      message.warning(
-        tr(
-          '连接器不在线，无法扫描应用',
-          'Edge is offline, cannot scan applications',
-        ),
+      return tr(
+        '连接器不在线，无法扫描应用',
+        'Edge is offline, cannot scan applications',
       );
+    }
+    return '';
+  };
+
+  const handleDiscoverApps = async (edge: API.Edge) => {
+    const disabledReason = getScanDisabledReason(edge);
+    if (disabledReason) {
+      message.warning(disabledReason);
       return;
     }
 
@@ -208,6 +213,11 @@ const ConnectorPage: React.FC = () => {
   // 重新扫描应用（强制创建新任务）
   const handleRescan = async () => {
     if (!currentRow?.id) return;
+    const disabledReason = getScanDisabledReason(currentRow);
+    if (disabledReason) {
+      message.warning(disabledReason);
+      return;
+    }
     setScanning(true);
     setScanTask(undefined);
 
@@ -485,9 +495,19 @@ const ConnectorPage: React.FC = () => {
       align: 'center',
       render: (_, record) => (
         <Space>
-          <a onClick={() => handleDiscoverApps(record)}>
-            {tr('扫描应用', 'Scan Apps')}
-          </a>
+          <Tooltip title={getScanDisabledReason(record) || undefined}>
+            <span>
+              <Button
+                type="link"
+                size="small"
+                disabled={!!getScanDisabledReason(record)}
+                style={{ padding: 0, height: 'auto' }}
+                onClick={() => handleDiscoverApps(record)}
+              >
+                {tr('扫描应用', 'Scan Apps')}
+              </Button>
+            </span>
+          </Tooltip>
           <a
             onClick={() => {
               setCurrentRow(record);
@@ -519,17 +539,13 @@ const ConnectorPage: React.FC = () => {
           rowKey="id"
           columns={columns}
           request={async (params) => {
-            console.log('ProTable request params:', params);
             const searchParams = buildSearchParams<API.EdgeListParams>(params, [
               'name',
               'device_name',
             ]);
-            console.log('buildSearchParams result:', searchParams);
             return tableRequest(() => getEdgeList(searchParams), 'edges');
           }}
-          onSubmit={(values) => {
-            console.log('ProTable onSubmit:', values);
-            // 触发表格刷新，此时会使用表单值
+          onSubmit={() => {
             actionRef.current?.reload();
           }}
           toolBarRender={() => [
@@ -879,7 +895,12 @@ const ConnectorPage: React.FC = () => {
               </Text>
               {(scanTask.task_status === 'completed' ||
                 scanTask.task_status === 'failed') && (
-                <Button size="small" onClick={handleRescan} loading={scanning}>
+                <Button
+                  size="small"
+                  onClick={handleRescan}
+                  loading={scanning}
+                  disabled={!!getScanDisabledReason(currentRow)}
+                >
                   {tr('重新扫描', 'Rescan')}
                 </Button>
               )}

--- a/web/src/pages/Proxy/index.tsx
+++ b/web/src/pages/Proxy/index.tsx
@@ -92,16 +92,67 @@ const ProxyPage: React.FC = () => {
   const [clientIP, setClientIP] = useState<string | null>(null);
   const [firewallSaving, setFirewallSaving] = useState(false);
 
+  const isValidIPv4Address = (value: string): boolean => {
+    const parts = value.split('.');
+    if (parts.length !== 4) return false;
+    return parts.every((part) => {
+      if (!/^\d+$/.test(part)) return false;
+      if (part.length > 1 && part.startsWith('0')) return false;
+      const octet = Number(part);
+      return octet >= 0 && octet <= 255;
+    });
+  };
+
   // IPv4 地址或带前缀的 IPv4 CIDR。纯 IP 保存时会自动补 /32。
   const isValidCIDR = (value: string): boolean => {
     const trimmed = value.trim();
-    return /^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[12][0-9]|3[0-2]))?$/.test(
-      trimmed,
-    );
+    const parts = trimmed.split('/');
+    if (parts.length > 2 || !isValidIPv4Address(parts[0])) return false;
+    if (parts.length === 1) return true;
+    if (!/^\d+$/.test(parts[1])) return false;
+    const prefix = Number(parts[1]);
+    return prefix >= 0 && prefix <= 32;
   };
   const normalizeCIDR = (value: string) => {
     const trimmed = value.trim();
     return trimmed.includes('/') ? trimmed : `${trimmed}/32`;
+  };
+
+  const validatePublicPort = async (
+    value?: number,
+    excludeProxyID?: number,
+  ) => {
+    if (value === undefined || value === null) return Promise.resolve();
+    if (!Number.isInteger(value) || value < 1 || value > 65535) {
+      return Promise.reject(
+        new Error(
+          tr(
+            '公网端口必须在1-65535之间',
+            'Public port must be between 1 and 65535',
+          ),
+        ),
+      );
+    }
+    try {
+      const res = await getProxyList({ page_size: 10000 });
+      const conflict = res.data?.proxies?.find(
+        (proxy: API.Proxy) =>
+          proxy.port === value && proxy.id !== excludeProxyID,
+      );
+      if (conflict) {
+        return Promise.reject(
+          new Error(
+            tr(
+              `公网端口 ${value} 已被访问「${conflict.name}」使用`,
+              `Public port ${value} is already used by entry "${conflict.name}"`,
+            ),
+          ),
+        );
+      }
+    } catch {
+      // 后端仍会做最终冲突校验；列表预校验失败时不阻塞表单。
+    }
+    return Promise.resolve();
   };
 
   const openFirewallDrawer = async (record: API.Proxy) => {
@@ -197,6 +248,18 @@ const ProxyPage: React.FC = () => {
   const handleFirewallSave = async () => {
     const record = firewallDrawer.record;
     if (!record?.id) return;
+    const invalidCIDR = firewallDrawer.draftCIDRs.find(
+      (cidr) => !isValidCIDR(cidr),
+    );
+    if (invalidCIDR) {
+      message.error(
+        tr(
+          `来源规则 ${invalidCIDR} 不是合法的 IPv4 CIDR`,
+          `Source rule ${invalidCIDR} is not a valid IPv4 CIDR`,
+        ),
+      );
+      return;
+    }
     setFirewallSaving(true);
     await executeAction(
       () =>
@@ -423,7 +486,7 @@ const ProxyPage: React.FC = () => {
     const result = await executeAction(
       () =>
         createProxy({
-          name: values.name,
+          name: values.name?.trim(),
           description: values.description,
           port: createPort,
           application_id: values.application_id,
@@ -449,7 +512,7 @@ const ProxyPage: React.FC = () => {
     return executeAction(
       () =>
         updateProxy(currentRow.id, {
-          name: values.name,
+          name: values.name?.trim(),
           description: values.description,
           port: values.port,
         }),
@@ -775,6 +838,12 @@ const ProxyPage: React.FC = () => {
           placeholder={tr('留空自动分配', 'Leave empty for auto allocation')}
           min={1}
           max={65535}
+          fieldProps={{ precision: 0 }}
+          rules={[
+            {
+              validator: (_: any, value?: number) => validatePublicPort(value),
+            },
+          ]}
           extra={tr(
             '映射到公网的端口号，留空则自动分配',
             'Mapped public port, empty means auto allocation',
@@ -813,6 +882,13 @@ const ProxyPage: React.FC = () => {
           placeholder={tr('请输入端口', 'Please input port')}
           min={1}
           max={65535}
+          fieldProps={{ precision: 0 }}
+          rules={[
+            {
+              validator: (_: any, value?: number) =>
+                validatePublicPort(value, currentRow?.id),
+            },
+          ]}
         />
         <ProFormTextArea
           name="description"

--- a/web/src/pages/Settings/index.tsx
+++ b/web/src/pages/Settings/index.tsx
@@ -463,8 +463,22 @@ const SettingsPage: React.FC = () => {
           <Form.Item
             name="expires_in_days"
             label={tr('过期天数（0 或留空表示永不过期）', 'Expires in days (0 or blank = never)')}
+            rules={[
+              {
+                type: 'integer',
+                min: 0,
+                max: 3650,
+                message: tr('请输入 0-3650 之间的整数', 'Enter an integer between 0 and 3650'),
+              },
+            ]}
           >
-            <InputNumber min={0} style={{ width: '100%' }} placeholder="0" />
+            <InputNumber
+              min={0}
+              max={3650}
+              precision={0}
+              style={{ width: '100%' }}
+              placeholder="0"
+            />
           </Form.Item>
           <Form.Item>
             <Space>


### PR DESCRIPTION
## Summary

- Add structured control-plane errors so expected validation, not-found, conflict, and precondition failures return concrete HTTP status codes instead of generic 500s.
- Add backend validation for Edge, Device, Application, Proxy, traffic query, scan task, and firewall proxy lookup flows.
- Improve frontend validation for application hosts, public ports, firewall CIDRs, scan availability, and PAT expiration days.
- Keep application host validation aligned with current runtime support by accepting IPv4, localhost, and hostnames, while rejecting IPv6 until runtime destination handling is IPv6-safe.

## Why

Invalid lifecycle and configuration states were previously surfaced as generic 500 errors or only failed after the operation reached backend/runtime code. This makes both the API and UI return clearer reasons earlier, while still keeping backend validation as the final source of truth.

## Validation

- `git diff --check`
- `ASDF_GOLANG_VERSION=1.23.9 GOTOOLCHAIN=auto go test ./pkg/liaison/manager/...`
- `npm run build`
