### PR TITLE
[codex] automate server releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Server Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, for example 1.6.0 or v1.6.0'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: server-release-${{ github.ref_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            raw="${{ inputs.version }}"
+          else
+            raw="${GITHUB_REF_NAME}"
+          fi
+
+          version="${raw#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release version: $raw" >&2
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+  edge-darwin:
+    needs: metadata
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Sync release metadata
+        run: make version=${{ needs.metadata.outputs.version }}
+
+      - name: Package macOS edge binaries
+        run: make package-edge-darwin-amd64 package-edge-darwin-arm64
+
+      - name: Upload macOS edge packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: edge-darwin-packages
+          path: packages/edge/liaison-edge-darwin-*.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+  release:
+    needs:
+      - metadata
+      - edge-darwin
+    runs-on: ubuntu-latest
+    timeout-minutes: 80
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Setup QEMU for arm64 edge packaging
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Sync release metadata
+        run: make version=${{ needs.metadata.outputs.version }}
+
+      - name: Build Linux server, web, tools, and non-macOS edge packages
+        run: |
+          make build-linux
+          make package-edge-linux-amd64 package-edge-linux-arm64 package-edge-windows-amd64
+          make build-web
+          make build-tools-linux
+
+      - name: Download macOS edge packages
+        uses: actions/download-artifact@v4
+        with:
+          name: edge-darwin-packages
+          path: packages/edge
+
+      - name: Package server tarball
+        run: |
+          chmod +x dist/package.sh
+          ./dist/package.sh
+
+      - name: Package offline Docker bundle
+        run: make package-docker
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          version="${{ needs.metadata.outputs.version }}"
+          sha256sum \
+            "liaison-${version}-linux-amd64.tar.gz" \
+            "liaison-${version}-docker-amd64.tar.gz" \
+            > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.metadata.outputs.tag }}
+          name: Liaison ${{ needs.metadata.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            liaison-${{ needs.metadata.outputs.version }}-linux-amd64.tar.gz
+            liaison-${{ needs.metadata.outputs.version }}-docker-amd64.tar.gz
+            SHA256SUMS
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,15 @@ endef
 define local-build-darwin
 	@echo "Building $(2) for darwin-$(1)..."
 	@mkdir -p ./bin
-	@CGO_ENABLED=1 GOOS=darwin GOARCH=$(1) go build $(GO_BUILD_FLAGS) -o ./bin/$(2) $(3)
+	@if [ "$$(uname)" != "Darwin" ]; then \
+		echo "❌ Error: darwin CGO builds must run on macOS"; \
+		exit 1; \
+	fi
+	@ARCH_FLAG="$$(if [ "$(1)" = "amd64" ]; then echo "x86_64"; else echo "arm64"; fi)" && \
+		CGO_ENABLED=1 GOOS=darwin GOARCH=$(1) \
+		CC="clang -arch $$ARCH_FLAG" \
+		CXX="clang++ -arch $$ARCH_FLAG" \
+		go build $(GO_BUILD_FLAGS) -o ./bin/$(2) $(3)
 	@chmod +x ./bin/$(2)
 	@echo "✅ Built: ./bin/$(2)"
 endef
@@ -327,19 +335,7 @@ build-edge-darwin-arm64:
 
 .PHONY: build-edge-windows-amd64
 build-edge-windows-amd64: docker-image
-	@echo "Building liaison-edge for windows-amd64..."
-	@mkdir -p ./bin
-	@$(DOCKER_BASE) \
-		--platform linux/amd64 \
-		-e CGO_ENABLED=1 \
-		-e GOOS=windows \
-		-e GOARCH=amd64 \
-		-e GOTOOLCHAIN=auto \
-		$(DOCKER_IMAGE) sh -c "\
-			go env -w GOTOOLCHAIN=auto && \
-			go mod download && \
-			CGO_ENABLED=1 go build $(GO_BUILD_FLAGS) -o ./bin/liaison-edge-windows-amd64.exe cmd/edge/main.go"
-	@echo "✅ Built: ./bin/liaison-edge-windows-amd64.exe"
+	$(call docker-build-no-cgo,linux/amd64,windows,amd64,liaison-edge-windows-amd64.exe,cmd/edge/main.go)
 
 # ============================================================================
 # Tar command detection: prefer gtar (GNU tar) if available
@@ -359,11 +355,11 @@ package-edge-linux-amd64: build-edge-linux-amd64
 	@mkdir -p ./packages/edge
 	@TMP_DIR=$$(mktemp -d) && \
 		PACKAGE_PATH="$$(pwd)/packages/edge/liaison-edge-linux-amd64.tar.gz" && \
-		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-linux-amd64 $$TMP_DIR/liaison-edge && \
-		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template $$TMP_DIR/liaison-edge.yaml.template && \
-		cd $$TMP_DIR && \
-		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf $$PACKAGE_PATH liaison-edge liaison-edge.yaml.template && \
-		rm -rf $$TMP_DIR && \
+		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-linux-amd64 "$$TMP_DIR/liaison-edge" && \
+		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template "$$TMP_DIR/liaison-edge.yaml.template" && \
+		cd "$$TMP_DIR" && \
+		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf "$$PACKAGE_PATH" liaison-edge liaison-edge.yaml.template && \
+		rm -rf "$$TMP_DIR" && \
 		echo "✅ Package created: ./packages/edge/liaison-edge-linux-amd64.tar.gz"
 
 .PHONY: package-edge-linux-arm64
@@ -372,11 +368,11 @@ package-edge-linux-arm64: build-edge-linux-arm64
 	@mkdir -p ./packages/edge
 	@TMP_DIR=$$(mktemp -d) && \
 		PACKAGE_PATH="$$(pwd)/packages/edge/liaison-edge-linux-arm64.tar.gz" && \
-		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-linux-arm64 $$TMP_DIR/liaison-edge && \
-		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template $$TMP_DIR/liaison-edge.yaml.template && \
-		cd $$TMP_DIR && \
-		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf $$PACKAGE_PATH liaison-edge liaison-edge.yaml.template && \
-		rm -rf $$TMP_DIR && \
+		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-linux-arm64 "$$TMP_DIR/liaison-edge" && \
+		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template "$$TMP_DIR/liaison-edge.yaml.template" && \
+		cd "$$TMP_DIR" && \
+		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf "$$PACKAGE_PATH" liaison-edge liaison-edge.yaml.template && \
+		rm -rf "$$TMP_DIR" && \
 		echo "✅ Package created: ./packages/edge/liaison-edge-linux-arm64.tar.gz"
 
 .PHONY: package-edge-darwin-amd64
@@ -385,11 +381,11 @@ package-edge-darwin-amd64: build-edge-darwin-amd64
 	@mkdir -p ./packages/edge
 	@TMP_DIR=$$(mktemp -d) && \
 		PACKAGE_PATH="$$(pwd)/packages/edge/liaison-edge-darwin-amd64.tar.gz" && \
-		COPYFILE_DISABLE=1 cp -X ./bin/liaison-edge-darwin-amd64 $$TMP_DIR/liaison-edge && \
-		COPYFILE_DISABLE=1 cp -X ./dist/edge/liaison-edge.yaml.template $$TMP_DIR/liaison-edge.yaml.template && \
-		cd $$TMP_DIR && \
-		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf $$PACKAGE_PATH liaison-edge liaison-edge.yaml.template && \
-		rm -rf $$TMP_DIR && \
+		COPYFILE_DISABLE=1 cp -X ./bin/liaison-edge-darwin-amd64 "$$TMP_DIR/liaison-edge" && \
+		COPYFILE_DISABLE=1 cp -X ./dist/edge/liaison-edge.yaml.template "$$TMP_DIR/liaison-edge.yaml.template" && \
+		cd "$$TMP_DIR" && \
+		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf "$$PACKAGE_PATH" liaison-edge liaison-edge.yaml.template && \
+		rm -rf "$$TMP_DIR" && \
 		echo "✅ Package created: ./packages/edge/liaison-edge-darwin-amd64.tar.gz"
 
 .PHONY: package-edge-darwin-arm64
@@ -398,11 +394,11 @@ package-edge-darwin-arm64: build-edge-darwin-arm64
 	@mkdir -p ./packages/edge
 	@TMP_DIR=$$(mktemp -d) && \
 		PACKAGE_PATH="$$(pwd)/packages/edge/liaison-edge-darwin-arm64.tar.gz" && \
-		COPYFILE_DISABLE=1 cp -X ./bin/liaison-edge-darwin-arm64 $$TMP_DIR/liaison-edge && \
-		COPYFILE_DISABLE=1 cp -X ./dist/edge/liaison-edge.yaml.template $$TMP_DIR/liaison-edge.yaml.template && \
-		cd $$TMP_DIR && \
-		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf $$PACKAGE_PATH liaison-edge liaison-edge.yaml.template && \
-		rm -rf $$TMP_DIR && \
+		COPYFILE_DISABLE=1 cp -X ./bin/liaison-edge-darwin-arm64 "$$TMP_DIR/liaison-edge" && \
+		COPYFILE_DISABLE=1 cp -X ./dist/edge/liaison-edge.yaml.template "$$TMP_DIR/liaison-edge.yaml.template" && \
+		cd "$$TMP_DIR" && \
+		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf "$$PACKAGE_PATH" liaison-edge liaison-edge.yaml.template && \
+		rm -rf "$$TMP_DIR" && \
 		echo "✅ Package created: ./packages/edge/liaison-edge-darwin-arm64.tar.gz"
 
 .PHONY: package-edge-windows-amd64
@@ -411,11 +407,11 @@ package-edge-windows-amd64: build-edge-windows-amd64
 	@mkdir -p ./packages/edge
 	@TMP_DIR=$$(mktemp -d) && \
 		PACKAGE_PATH="$$(pwd)/packages/edge/liaison-edge-windows-amd64.tar.gz" && \
-		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-windows-amd64.exe $$TMP_DIR/liaison-edge.exe && \
-		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template $$TMP_DIR/liaison-edge.yaml.template && \
-		cd $$TMP_DIR && \
-		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf $$PACKAGE_PATH liaison-edge.exe liaison-edge.yaml.template && \
-		rm -rf $$TMP_DIR && \
+		COPYFILE_DISABLE=1 cp ./bin/liaison-edge-windows-amd64.exe "$$TMP_DIR/liaison-edge.exe" && \
+		COPYFILE_DISABLE=1 cp ./dist/edge/liaison-edge.yaml.template "$$TMP_DIR/liaison-edge.yaml.template" && \
+		cd "$$TMP_DIR" && \
+		COPYFILE_DISABLE=1 $(TAR_CMD) --exclude='._*' --exclude='.DS_Store' -czf "$$PACKAGE_PATH" liaison-edge.exe liaison-edge.yaml.template && \
+		rm -rf "$$TMP_DIR" && \
 		echo "✅ Package created: ./packages/edge/liaison-edge-windows-amd64.tar.gz"
 
 # Legacy aliases
@@ -546,19 +542,5 @@ update-version version:
 		echo "❌ Error: missing version. Usage: make version=1.2.7"; \
 		exit 1; \
 	fi
-	@RAW_VERSION="$(version)"; \
-	if echo "$$RAW_VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		NEW_VERSION="$$RAW_VERSION"; \
-	elif echo "$$RAW_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		NEW_VERSION="v$$RAW_VERSION"; \
-	else \
-		echo "❌ Error: invalid version '$$RAW_VERSION'. Expect 1.2.7 or v1.2.7"; \
-		exit 1; \
-	fi; \
-	echo "$$NEW_VERSION" > VERSION; \
-	for f in README.md README_zh.md README_ja.md README_ko.md README_es.md README_fr.md README_de.md; do \
-		if [ -f "$$f" ]; then \
-			sed -E "s/v[0-9]+\.[0-9]+\.[0-9]+/$$NEW_VERSION/g" "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
-		fi; \
-	done; \
-	echo "✅ Updated version to $$NEW_VERSION in VERSION + all language READMEs"
+	@chmod +x scripts/sync-release-version.sh
+	@scripts/sync-release-version.sh "$(version)"

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ cd liaison-1.5.0-docker-amd64
 
 | 平台 | 文件 |
 |:---|:---|
-| macOS（Apple Silicon + Intel 通用） | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows（.msi 安装器） | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows（.exe NSIS，卸载时清理 keychain） | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS（Apple Silicon + Intel 通用） | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows（.msi 安装器） | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows（.exe NSIS，卸载时清理 keychain） | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > v0.1 的安装包未签名。macOS Gatekeeper 与 Windows SmartScreen 首次启动会提示——macOS 上右键点击 → 打开，Windows 上选「更多信息」→「仍要运行」。Windows 需要 WebView2 Runtime；Win10 1803+ 和 Win11 已自带。
 

--- a/README_de.md
+++ b/README_de.md
@@ -114,9 +114,9 @@ Menüleisten- / Tray-App, die den Konnektor umschließt und Single-Click-Anmeldu
 
 | Plattform | Datei |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (.msi-Installer) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS, mit Keychain-Bereinigung beim Deinstallieren) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (.msi-Installer) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS, mit Keychain-Bereinigung beim Deinstallieren) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > Die v0.1-Installer sind unsigniert. macOS Gatekeeper und Windows SmartScreen warnen beim ersten Start — Rechtsklick → Öffnen auf macOS, oder „Weitere Informationen" → „Trotzdem ausführen" auf Windows. WebView2 Runtime ist auf Windows erforderlich; Win10 1803+ und Win11 enthalten es.
 

--- a/README_en.md
+++ b/README_en.md
@@ -114,9 +114,9 @@ A menubar / tray app that wraps the connector and gives you a single-click sign-
 
 | Platform | File |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (.msi installer) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS, with uninstall keychain cleanup) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (.msi installer) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS, with uninstall keychain cleanup) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > Both installers are unsigned for v0.1. macOS Gatekeeper and Windows SmartScreen will warn on first run — right-click → Open on macOS, or "More info" → "Run anyway" on Windows. WebView2 Runtime is required at runtime on Windows; Win10 1803+ and Win11 ship it.
 

--- a/README_es.md
+++ b/README_es.md
@@ -114,9 +114,9 @@ App de barra de menú / bandeja del sistema que envuelve al conector y ofrece in
 
 | Plataforma | Archivo |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (instalador .msi) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS, con limpieza de keychain al desinstalar) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (instalador .msi) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS, con limpieza de keychain al desinstalar) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > Los instaladores de v0.1 no están firmados. Gatekeeper de macOS y Windows SmartScreen avisarán al primer arranque — clic derecho → Abrir en macOS, o "Más información" → "Ejecutar de todos modos" en Windows. WebView2 Runtime es necesario en Windows; Win10 1803+ y Win11 lo incluyen.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -114,9 +114,9 @@ Application de barre de menus / barre d'état système qui encapsule le connecte
 
 | Plateforme | Fichier |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universel) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (installateur .msi) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS, avec nettoyage du trousseau à la désinstallation) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universel) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (installateur .msi) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS, avec nettoyage du trousseau à la désinstallation) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > Les installateurs v0.1 ne sont pas signés. Gatekeeper macOS et Windows SmartScreen avertiront au premier lancement — clic droit → Ouvrir sur macOS, ou « Informations supplémentaires » → « Exécuter quand même » sur Windows. WebView2 Runtime est requis sur Windows ; Win10 1803+ et Win11 l'incluent.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -114,9 +114,9 @@ cd liaison-1.5.0-docker-amd64
 
 | プラットフォーム | ファイル |
 |:---|:---|
-| macOS (Apple Silicon + Intel ユニバーサル) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (.msi インストーラー) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS、アンインストール時にキーチェーンクリーンアップ) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel ユニバーサル) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (.msi インストーラー) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS、アンインストール時にキーチェーンクリーンアップ) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > v0.1 のインストーラーは未署名です。macOS Gatekeeper と Windows SmartScreen が初回起動時に警告を出します — macOS は右クリック → 開く、Windows は「詳細情報」→「実行」を選択してください。Windows には WebView2 Runtime が必要です (Win10 1803+ と Win11 にプリインストール済み)。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -114,9 +114,9 @@ cd liaison-1.5.0-docker-amd64
 
 | 플랫폼 | 파일 |
 |:---|:---|
-| macOS (Apple Silicon + Intel 유니버설) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
-| Windows (.msi 설치 프로그램) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
-| Windows (.exe NSIS, 제거 시 키체인 정리 포함) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
+| macOS (Apple Silicon + Intel 유니버설) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
+| Windows (.msi 설치 프로그램) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
+| Windows (.exe NSIS, 제거 시 키체인 정리 포함) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
 
 > v0.1 설치 프로그램은 서명되지 않았습니다. macOS Gatekeeper 와 Windows SmartScreen 이 첫 실행 시 경고를 표시합니다 — macOS 는 우클릭 → 열기, Windows 는 "추가 정보" → "실행"을 선택하세요. Windows 에는 WebView2 Runtime 이 필요합니다 (Win10 1803+ 와 Win11 에 기본 포함).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+# Release
+
+Liaison uses one repository and two release tag families:
+
+- `vX.Y.Z` publishes the server platform release: `liaison`, `frontier`, the Web console, CLI edge packages, and the offline Docker bundle.
+- `desktop-vX.Y.Z` publishes the desktop client installers. Use it only when `desktop-client/**` or desktop-bundled edge behavior changes.
+
+## Server Release
+
+1. Sync the release version in docs:
+
+   ```bash
+   make version=1.6.0
+   ```
+
+   This keeps `VERSION` as `1.6.0`, updates localized README badges, and rewrites server download URLs to `v1.6.0`.
+
+2. Commit the version/docs change and merge it to `main`.
+
+3. Create and push a server release tag from the target commit:
+
+   ```bash
+   git tag v1.6.0
+   git push origin v1.6.0
+   ```
+
+4. GitHub Actions runs `Server Release` and uploads:
+
+   ```text
+   liaison-1.6.0-linux-amd64.tar.gz
+   liaison-1.6.0-docker-amd64.tar.gz
+   SHA256SUMS
+   ```
+
+The platform package already contains CLI edge packages for Linux, macOS, and Windows under its `edge/` directory, so edge packages are not uploaded as separate release assets.
+
+The release workflow also runs the version sync in its checkout, so the README files embedded in the release tarball always match the tag.
+
+The same workflow can also be started manually from GitHub Actions with a version input, but tag-based release is the normal path.
+
+## Desktop Release
+
+Create a desktop tag only when the desktop app itself or its bundled edge behavior changed:
+
+```bash
+git tag desktop-v1.6.0
+git push origin desktop-v1.6.0
+```

--- a/deploy/docker/package-docker.sh
+++ b/deploy/docker/package-docker.sh
@@ -79,6 +79,7 @@ rm -f "$PACK_DIR/.env.example.tmp"
 
 cp deploy/docker/load.sh "$PACK_DIR/load.sh"
 cp deploy/docker/uninstall.sh "$PACK_DIR/uninstall.sh"
+cp LICENSE "$PACK_DIR/LICENSE"
 chmod +x "$PACK_DIR/load.sh" "$PACK_DIR/uninstall.sh"
 
 cat > "$PACK_DIR/README.md" <<EOF

--- a/dist/package.sh
+++ b/dist/package.sh
@@ -250,6 +250,9 @@ if [[ "$(uname)" == "Darwin" ]]; then
     if [ -f "VERSION" ]; then
         cp -X VERSION "$PACK_DIR/" 2>/dev/null || cp VERSION "$PACK_DIR/"
     fi
+    if [ -f "LICENSE" ]; then
+        cp -X LICENSE "$PACK_DIR/" 2>/dev/null || cp LICENSE "$PACK_DIR/"
+    fi
 else
     if [ -f "dist/liaison/README.md" ]; then
         cp dist/liaison/README.md "$PACK_DIR/" 2>/dev/null || true
@@ -259,6 +262,9 @@ else
     fi
     if [ -f "VERSION" ]; then
         cp VERSION "$PACK_DIR/"
+    fi
+    if [ -f "LICENSE" ]; then
+        cp LICENSE "$PACK_DIR/"
     fi
 fi
 

--- a/scripts/sync-release-version.sh
+++ b/scripts/sync-release-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <version>"
+    echo "Example: $0 1.6.0"
+    echo "         $0 v1.6.0"
+}
+
+if [ "${1:-}" = "" ]; then
+    usage >&2
+    exit 1
+fi
+
+RAW_VERSION="$1"
+VERSION="${RAW_VERSION#v}"
+TAG="v${VERSION}"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: invalid version '${RAW_VERSION}'. Expect 1.6.0 or v1.6.0" >&2
+    exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+echo "$VERSION" > VERSION
+
+README_FILES=(
+    README.md
+    README_en.md
+    README_ja.md
+    README_ko.md
+    README_es.md
+    README_fr.md
+    README_de.md
+)
+
+for file in "${README_FILES[@]}"; do
+    [ -f "$file" ] || continue
+
+    VERSION="$VERSION" TAG="$TAG" perl -0pi -e '
+        my $version = $ENV{"VERSION"};
+        my $tag = $ENV{"TAG"};
+
+        s{Version-v[0-9]+\.[0-9]+\.[0-9]+}{Version-$tag}g;
+        s{releases/download/v[0-9]+\.[0-9]+\.[0-9]+}{releases/download/$tag}g;
+        s{liaison-[0-9]+\.[0-9]+\.[0-9]+-(linux|docker)-amd64\.tar\.gz}{liaison-$version-$1-amd64.tar.gz}g;
+        s{cd liaison-[0-9]+\.[0-9]+\.[0-9]+-(linux|docker)-amd64}{cd liaison-$version-$1-amd64}g;
+
+        s{Liaison_0\.1\.0_universal\.dmg}{Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg}g;
+        s{Liaison_0\.1\.0_x64_en-US\.msi}{Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi}g;
+        s{Liaison_0\.1\.0_x64-setup\.exe}{Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe}g;
+    ' "$file"
+done
+
+echo "Updated release version to ${TAG}"


### PR DESCRIPTION
## Summary

Adds automated server release publishing for `vX.Y.Z` tags.

## Changes

- Add a `Server Release` GitHub Actions workflow triggered by server tags and manual dispatch.
- Build and publish only the final server assets:
  - `liaison-X.Y.Z-linux-amd64.tar.gz`
  - `liaison-X.Y.Z-docker-amd64.tar.gz`
  - `SHA256SUMS`
- Keep CLI Edge packages embedded inside the server tarball instead of uploading them as separate release assets.
- Add `scripts/sync-release-version.sh` and wire `make version=...` to keep `VERSION` and localized README download links in sync.
- Add `RELEASE.md` documenting `vX.Y.Z` versus `desktop-vX.Y.Z` release ownership.
- Include `LICENSE` in binary and Docker bundles.
- Quote edge package paths so local workspaces with spaces still package correctly.
- Align Windows edge packaging with the no-CGO cross-compile path used by desktop builds.

## Validation

- `git diff --check`
- `bash -n scripts/sync-release-version.sh dist/package.sh deploy/docker/package-docker.sh`
- Ruby YAML parse for `.github/workflows/release.yml`
- `./scripts/sync-release-version.sh 1.5.0`
- Local packaging smoke test:
  - `make package-edge-darwin-arm64`
  - `make package-edge-darwin-amd64`
