### PR TITLE
[codex] restore desktop readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ cd liaison-1.6.0-docker-amd64
 
 | 平台 | 文件 |
 |:---|:---|
-| macOS（Apple Silicon + Intel 通用） | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows（.msi 安装器） | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows（.exe NSIS，卸载时清理 keychain） | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS（Apple Silicon + Intel 通用） | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows（.msi 安装器） | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows（.exe NSIS，卸载时清理 keychain） | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > v0.1 的安装包未签名。macOS Gatekeeper 与 Windows SmartScreen 首次启动会提示——macOS 上右键点击 → 打开，Windows 上选「更多信息」→「仍要运行」。Windows 需要 WebView2 Runtime；Win10 1803+ 和 Win11 已自带。
 

--- a/README_de.md
+++ b/README_de.md
@@ -114,9 +114,9 @@ Menüleisten- / Tray-App, die den Konnektor umschließt und Single-Click-Anmeldu
 
 | Plattform | Datei |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (.msi-Installer) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS, mit Keychain-Bereinigung beim Deinstallieren) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (.msi-Installer) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS, mit Keychain-Bereinigung beim Deinstallieren) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > Die v0.1-Installer sind unsigniert. macOS Gatekeeper und Windows SmartScreen warnen beim ersten Start — Rechtsklick → Öffnen auf macOS, oder „Weitere Informationen" → „Trotzdem ausführen" auf Windows. WebView2 Runtime ist auf Windows erforderlich; Win10 1803+ und Win11 enthalten es.
 

--- a/README_en.md
+++ b/README_en.md
@@ -114,9 +114,9 @@ A menubar / tray app that wraps the connector and gives you a single-click sign-
 
 | Platform | File |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (.msi installer) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS, with uninstall keychain cleanup) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (.msi installer) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS, with uninstall keychain cleanup) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > Both installers are unsigned for v0.1. macOS Gatekeeper and Windows SmartScreen will warn on first run — right-click → Open on macOS, or "More info" → "Run anyway" on Windows. WebView2 Runtime is required at runtime on Windows; Win10 1803+ and Win11 ship it.
 

--- a/README_es.md
+++ b/README_es.md
@@ -114,9 +114,9 @@ App de barra de menú / bandeja del sistema que envuelve al conector y ofrece in
 
 | Plataforma | Archivo |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universal) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (instalador .msi) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS, con limpieza de keychain al desinstalar) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universal) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (instalador .msi) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS, con limpieza de keychain al desinstalar) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > Los instaladores de v0.1 no están firmados. Gatekeeper de macOS y Windows SmartScreen avisarán al primer arranque — clic derecho → Abrir en macOS, o "Más información" → "Ejecutar de todos modos" en Windows. WebView2 Runtime es necesario en Windows; Win10 1803+ y Win11 lo incluyen.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -114,9 +114,9 @@ Application de barre de menus / barre d'état système qui encapsule le connecte
 
 | Plateforme | Fichier |
 |:---|:---|
-| macOS (Apple Silicon + Intel, universel) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (installateur .msi) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS, avec nettoyage du trousseau à la désinstallation) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel, universel) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (installateur .msi) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS, avec nettoyage du trousseau à la désinstallation) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > Les installateurs v0.1 ne sont pas signés. Gatekeeper macOS et Windows SmartScreen avertiront au premier lancement — clic droit → Ouvrir sur macOS, ou « Informations supplémentaires » → « Exécuter quand même » sur Windows. WebView2 Runtime est requis sur Windows ; Win10 1803+ et Win11 l'incluent.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -114,9 +114,9 @@ cd liaison-1.6.0-docker-amd64
 
 | プラットフォーム | ファイル |
 |:---|:---|
-| macOS (Apple Silicon + Intel ユニバーサル) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (.msi インストーラー) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS、アンインストール時にキーチェーンクリーンアップ) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel ユニバーサル) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (.msi インストーラー) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS、アンインストール時にキーチェーンクリーンアップ) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > v0.1 のインストーラーは未署名です。macOS Gatekeeper と Windows SmartScreen が初回起動時に警告を出します — macOS は右クリック → 開く、Windows は「詳細情報」→「実行」を選択してください。Windows には WebView2 Runtime が必要です (Win10 1803+ と Win11 にプリインストール済み)。
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -114,9 +114,9 @@ cd liaison-1.6.0-docker-amd64
 
 | 플랫폼 | 파일 |
 |:---|:---|
-| macOS (Apple Silicon + Intel 유니버설) | [`Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg) |
-| Windows (.msi 설치 프로그램) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi) |
-| Windows (.exe NSIS, 제거 시 키체인 정리 포함) | [`Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe) |
+| macOS (Apple Silicon + Intel 유니버설) | [`Liaison_0.1.0_universal.dmg`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_universal.dmg) |
+| Windows (.msi 설치 프로그램) | [`Liaison_0.1.0_x64_en-US.msi`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64_en-US.msi) |
+| Windows (.exe NSIS, 제거 시 키체인 정리 포함) | [`Liaison_0.1.0_x64-setup.exe`](https://github.com/liaisonio/liaison/releases/download/desktop-latest/Liaison_0.1.0_x64-setup.exe) |
 
 > v0.1 설치 프로그램은 서명되지 않았습니다. macOS Gatekeeper 와 Windows SmartScreen 이 첫 실행 시 경고를 표시합니다 — macOS 는 우클릭 → 열기, Windows 는 "추가 정보" → "실행"을 선택하세요. Windows 에는 WebView2 Runtime 이 필요합니다 (Win10 1803+ 와 Win11 에 기본 포함).
 

--- a/scripts/sync-release-version.sh
+++ b/scripts/sync-release-version.sh
@@ -48,9 +48,6 @@ for file in "${README_FILES[@]}"; do
         s{liaison-[0-9]+\.[0-9]+\.[0-9]+-(linux|docker)-amd64\.tar\.gz}{liaison-$version-$1-amd64.tar.gz}g;
         s{cd liaison-[0-9]+\.[0-9]+\.[0-9]+-(linux|docker)-amd64}{cd liaison-$version-$1-amd64}g;
 
-        s{Liaison_0\.1\.0_universal\.dmg}{Liaison-Desktop-dev-feat-desktop-client-macOS-universal.dmg}g;
-        s{Liaison_0\.1\.0_x64_en-US\.msi}{Liaison-Desktop-dev-feat-desktop-client-Windows-x64.msi}g;
-        s{Liaison_0\.1\.0_x64-setup\.exe}{Liaison-Desktop-dev-feat-desktop-client-Windows-x64-setup.exe}g;
     ' "$file"
 done
 


### PR DESCRIPTION
## Summary

Restores the desktop-client download links in localized READMEs and keeps server version sync scoped to server release assets only.

## Changes

- Restore `desktop-latest` README links back to the existing `Liaison_0.1.0_*` filenames.
- Remove the desktop link rewrite rules from `scripts/sync-release-version.sh`.
- Keep server version references at `v1.6.0` / `liaison-1.6.0-*`.

## Why

The server release version sync should update server artifacts only. Desktop installers follow the separate desktop release workflow and should not be renamed by `make version=...`.

## Validation

- `git diff --check`
- `bash -n scripts/sync-release-version.sh`
- Re-ran `./scripts/sync-release-version.sh 1.6.0` and confirmed it is idempotent.
- Verified no `Liaison-Desktop-dev-feat-desktop-client` or `v1.5.0` server links remain in README files.
