### PR TITLE
[codex] disable vcs stamping for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ DOCKER_WORKDIR = -w /build
 DOCKER_BASE = docker run --rm $(DOCKER_VOLUME) $(DOCKER_WORKDIR)
 DOCKER_HOST_UID := $(shell id -u 2>/dev/null || echo 0)
 DOCKER_HOST_GID := $(shell id -g 2>/dev/null || echo 0)
-GO_BUILD_FLAGS = -trimpath -ldflags '-s -w'
+GO_BUILD_FLAGS = -trimpath -buildvcs=false -ldflags '-s -w'
 
 # Ensure Docker image exists (pull only if not present locally)
 .PHONY: docker-image


### PR DESCRIPTION
## Summary

Fixes the next server release failure by disabling Go VCS stamping for release builds.

## Root Cause

The rerun of the `v1.6.0` release progressed past the previous Docker artifact ownership failure, but failed while building `password-verifier` inside Docker:

```text
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```

Go attempts to stamp VCS metadata into binaries by default. In the Docker-mounted GitHub Actions workspace, that VCS lookup can fail, which stops the release build.

## Fix

Add `-buildvcs=false` to the shared `GO_BUILD_FLAGS`, so all release binaries build without querying Git metadata.

## Validation

- `git diff --check`
- `make -n build-password-verifier-linux` confirms `-buildvcs=false` is included.
- `make -n build-liaison-linux` confirms the flag is included for server binaries too.
- Shell syntax checks for release scripts.
- YAML parse for `.github/workflows/release.yml`.
