### PR TITLE
[codex] fix server release cache cleanup failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Sync release metadata
         run: make version=${{ needs.metadata.outputs.version }}


### PR DESCRIPTION
## Summary
- Remove the optional pnpm cache from the server release job so `actions/setup-node` post-cleanup cannot fail after release assets are uploaded.
- Keep Node and pnpm setup intact for the web build; only the fragile cache save path is disabled.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`