### PR TITLE
[codex] refine session watermark UI

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1,5 +1,5 @@
 import { history, RequestConfig } from '@umijs/max';
-import { ConfigProvider, Dropdown, message, Typography, Tooltip } from 'antd';
+import { ConfigProvider, Dropdown, message, Typography } from 'antd';
 import { LogoutOutlined, SettingOutlined, BugOutlined, GlobalOutlined } from '@ant-design/icons';
 import React from 'react';
 import enUS from 'antd/locale/en_US';
@@ -349,61 +349,6 @@ export const layout = ({ initialState }: any) => {
               },
             }),
             React.createElement('span', null, 'Github')
-          ),
-          React.createElement(
-            Tooltip,
-            {
-              title: React.createElement('img', {
-                src: '/wechat.png',
-                alt: tr('微信二维码', 'WeChat QR Code'),
-                style: {
-                  width: 200,
-                  height: 200,
-                  display: 'block',
-                },
-              }),
-              placement: 'top',
-              overlayStyle: {
-                padding: 0,
-              },
-              overlayInnerStyle: {
-                padding: 8,
-                backgroundColor: '#fff',
-                borderRadius: 8,
-                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-              },
-            },
-            React.createElement(
-              'div',
-              {
-                style: {
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  cursor: 'pointer',
-                  color: 'rgba(0, 0, 0, 0.45)',
-                  fontSize: 13,
-                },
-              },
-              React.createElement('img', {
-                src: '/wechat.svg',
-                alt: 'WeChat',
-                style: {
-                  width: 18,
-                  height: 18,
-                  verticalAlign: 'middle',
-                  opacity: 0.7,
-                  transition: 'opacity 0.3s',
-                },
-                onMouseEnter: (e: any) => {
-                  e.currentTarget.style.opacity = '1';
-                },
-                onMouseLeave: (e: any) => {
-                  e.currentTarget.style.opacity = '0.7';
-                },
-              }),
-              React.createElement('span', null, 'WeChat')
-            )
           )
         )
       );

--- a/web/src/components/SessionWatermark/index.less
+++ b/web/src/components/SessionWatermark/index.less
@@ -1,0 +1,72 @@
+.session-watermark {
+  position: absolute;
+  z-index: 2;
+  inset: -10%;
+  display: grid;
+  overflow: hidden;
+  padding: 22px;
+  gap: 26px 46px;
+  grid-auto-rows: 118px;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  pointer-events: none;
+  user-select: none;
+}
+
+.session-watermark__tile {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 3px;
+  color: rgba(255, 255, 255, 0.12);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.2;
+  mix-blend-mode: difference;
+  text-align: center;
+  text-shadow: 0 0 1px rgba(15, 23, 42, 0.18);
+  transform: rotate(-22deg);
+}
+
+.session-watermark__tile span {
+  max-width: 500px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-watermark__tile span + span {
+  font-size: 12px;
+  font-weight: 400;
+  opacity: 0.88;
+}
+
+@media (min-width: 1440px) {
+  .session-watermark {
+    gap: 30px 56px;
+    grid-auto-rows: 128px;
+    grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  }
+
+  .session-watermark__tile span {
+    max-width: 560px;
+  }
+}
+
+@media (max-width: 768px) {
+  .session-watermark {
+    gap: 18px 24px;
+    grid-auto-rows: 104px;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  .session-watermark__tile {
+    font-size: 12px;
+  }
+
+  .session-watermark__tile span {
+    max-width: 320px;
+  }
+}

--- a/web/src/components/SessionWatermark/index.tsx
+++ b/web/src/components/SessionWatermark/index.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import './index.less';
+
+const watermarkTileCount = 96;
+const watermarkTileIndexes = Array.from(
+  { length: watermarkTileCount },
+  (_, index) => index,
+);
+
+const padTimePart = (value: number) => String(value).padStart(2, '0');
+
+const formatSessionWatermarkTime = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = padTimePart(now.getMonth() + 1);
+  const day = padTimePart(now.getDate());
+  const hour = padTimePart(now.getHours());
+  const minute = padTimePart(now.getMinutes());
+  return `${year}-${month}-${day} ${hour}:${minute}`;
+};
+
+export const useSessionWatermarkTime = () => {
+  const [time, setTime] = useState(formatSessionWatermarkTime);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setTime(formatSessionWatermarkTime());
+    }, 60_000);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  return time;
+};
+
+export const buildSessionWatermarkLabel = (
+  parts: Array<string | number | undefined | null>,
+) => {
+  const seen = new Set<string>();
+  return parts
+    .map((part) => String(part ?? '').trim())
+    .filter(Boolean)
+    .filter((part) => {
+      if (seen.has(part)) return false;
+      seen.add(part);
+      return true;
+    })
+    .join(' · ');
+};
+
+type SessionWatermarkProps = {
+  lines: Array<string | undefined>;
+};
+
+const SessionWatermark: React.FC<SessionWatermarkProps> = ({ lines }) => {
+  const visibleLines = lines.filter(Boolean) as string[];
+  if (visibleLines.length === 0) return null;
+
+  return (
+    <div className="session-watermark" aria-hidden="true">
+      {watermarkTileIndexes.map((index) => (
+        <div className="session-watermark__tile" key={index}>
+          {visibleLines.map((line, lineIndex) => (
+            <span key={`${lineIndex}-${line}`}>{line}</span>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SessionWatermark;

--- a/web/src/pages/WebDesktop/index.less
+++ b/web/src/pages/WebDesktop/index.less
@@ -68,27 +68,6 @@ body.webdesktop-page-active .ant-pro-page-container-children-container {
   background: #111827;
 }
 
-.webdesktop-display::after {
-  position: absolute;
-  z-index: 2;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  color: rgba(226, 232, 240, 0.16);
-  content: attr(data-watermark);
-  font-size: clamp(22px, 4vw, 58px);
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.2;
-  pointer-events: none;
-  text-align: center;
-  transform: rotate(-18deg);
-  user-select: none;
-  white-space: pre-wrap;
-}
-
 .webdesktop-display:fullscreen {
   display: flex;
   width: 100vw;
@@ -111,8 +90,14 @@ body.webdesktop-page-active .ant-pro-page-container-children-container {
   background: #000000;
 }
 
-.webdesktop-display > div {
-  margin: 0 auto;
+.webdesktop-display-stage {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
 
 .webdesktop-native-display {

--- a/web/src/pages/WebDesktop/index.tsx
+++ b/web/src/pages/WebDesktop/index.tsx
@@ -1,3 +1,7 @@
+import SessionWatermark, {
+  buildSessionWatermarkLabel,
+  useSessionWatermarkTime,
+} from '@/components/SessionWatermark';
 import { useI18n } from '@/i18n';
 import {
   createWebDesktopSession,
@@ -12,7 +16,7 @@ import {
   SendOutlined,
 } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-components';
-import { useParams } from '@umijs/max';
+import { useModel, useParams } from '@umijs/max';
 import {
   Alert,
   AutoComplete,
@@ -38,6 +42,7 @@ const credentialKey = (username?: string, domain?: string) =>
 
 const WebDesktopPage: React.FC = () => {
   const { tr } = useI18n();
+  const { initialState } = useModel('@@initialState');
   const params = useParams();
   const proxyId = Number(params.proxyId);
   const [form] = Form.useForm<API.CreateWebDesktopSessionRequest>();
@@ -50,6 +55,7 @@ const WebDesktopPage: React.FC = () => {
   const [fullscreen, setFullscreen] = useState(false);
   const [error, setError] = useState('');
   const displayHostRef = useRef<HTMLDivElement | null>(null);
+  const displayContentRef = useRef<HTMLDivElement | null>(null);
   const clientRef = useRef<any>();
   const tunnelRef = useRef<any>();
   const keyboardRef = useRef<any>();
@@ -73,11 +79,24 @@ const WebDesktopPage: React.FC = () => {
         : item.username || '';
     return { label, value: key };
   });
-  const watermarkText = target
-    ? `WebDesktop · ${target.protocol.toUpperCase()} · ${target.proxy_name} · ${
-        target.application_name
-      } · ${target.target_host}:${target.target_port}`
-    : 'WebDesktop';
+  const watermarkTime = useSessionWatermarkTime();
+  const watermarkUser =
+    initialState?.currentUser?.email ||
+    initialState?.currentUser?.name ||
+    tr('未知用户', 'Unknown user');
+  const watermarkLines = target
+    ? [
+        buildSessionWatermarkLabel([
+          watermarkUser,
+          target.protocol.toUpperCase(),
+          target.proxy_name,
+        ]),
+        watermarkTime,
+      ]
+    : [
+        buildSessionWatermarkLabel([watermarkUser, 'WebDesktop']),
+        watermarkTime,
+      ];
 
   const cleanupConnection = useCallback(
     (close = false, clearDisplay = false) => {
@@ -99,8 +118,8 @@ const WebDesktopPage: React.FC = () => {
         client?.disconnect?.();
         tunnel?.disconnect?.();
       }
-      if (clearDisplay && displayHostRef.current) {
-        displayHostRef.current.innerHTML = '';
+      if (clearDisplay && displayContentRef.current) {
+        displayContentRef.current.innerHTML = '';
       }
       setConnected(false);
       setConnecting(false);
@@ -113,7 +132,7 @@ const WebDesktopPage: React.FC = () => {
   }, [cleanupConnection]);
 
   const focusRemoteCanvas = useCallback(() => {
-    const canvas = displayHostRef.current?.querySelector<HTMLCanvasElement>(
+    const canvas = displayContentRef.current?.querySelector<HTMLCanvasElement>(
       '.webdesktop-input-plane',
     );
     canvas?.focus({ preventScroll: true });
@@ -241,7 +260,13 @@ const WebDesktopPage: React.FC = () => {
   };
 
   const connect = async (values: API.CreateWebDesktopSessionRequest) => {
-    if (!target || !active || !displayHostRef.current) return;
+    if (
+      !target ||
+      !active ||
+      !displayHostRef.current ||
+      !displayContentRef.current
+    )
+      return;
     disconnect();
     setConnecting(true);
     setError('');
@@ -280,9 +305,9 @@ const WebDesktopPage: React.FC = () => {
       inputPlane.className = 'webdesktop-input-plane';
       inputPlane.tabIndex = 0;
       displayElement.classList.add('webdesktop-native-display');
-      displayHostRef.current.innerHTML = '';
-      displayHostRef.current.appendChild(displayElement);
-      displayHostRef.current.appendChild(inputPlane);
+      displayContentRef.current.innerHTML = '';
+      displayContentRef.current.appendChild(displayElement);
+      displayContentRef.current.appendChild(inputPlane);
 
       const fitDisplayToHost = () => {
         const host = displayHostRef.current;
@@ -679,11 +704,10 @@ const WebDesktopPage: React.FC = () => {
           </Form>
         </div>
 
-        <div
-          className="webdesktop-display"
-          data-watermark={watermarkText}
-          ref={displayHostRef}
-        />
+        <div className="webdesktop-display" ref={displayHostRef}>
+          <div className="webdesktop-display-stage" ref={displayContentRef} />
+          <SessionWatermark lines={watermarkLines} />
+        </div>
       </div>
     </PageContainer>
   );

--- a/web/src/pages/WebSSH/index.less
+++ b/web/src/pages/WebSSH/index.less
@@ -74,28 +74,6 @@ body.webssh-page-active .ant-pro-page-container-children-container {
   background: #101418;
 }
 
-.webssh-terminal::after {
-  position: absolute;
-  z-index: 2;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  color: rgba(226, 232, 240, 0.12);
-  content: attr(data-watermark);
-  font-size: clamp(20px, 4vw, 54px);
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.2;
-  pointer-events: none;
-  text-align: center;
-  text-transform: none;
-  transform: rotate(-18deg);
-  user-select: none;
-  white-space: pre-wrap;
-}
-
 .webssh-terminal:fullscreen {
   width: 100vw;
   height: 100vh;

--- a/web/src/pages/WebSSH/index.tsx
+++ b/web/src/pages/WebSSH/index.tsx
@@ -1,3 +1,7 @@
+import SessionWatermark, {
+  buildSessionWatermarkLabel,
+  useSessionWatermarkTime,
+} from '@/components/SessionWatermark';
 import { useI18n } from '@/i18n';
 import {
   createWebSSHSession,
@@ -14,7 +18,7 @@ import {
   SendOutlined,
 } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-components';
-import { useParams } from '@umijs/max';
+import { useModel, useParams } from '@umijs/max';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
@@ -48,6 +52,7 @@ const isTerminalAtBottom = (terminal?: Terminal) => {
 
 const WebSSHPage: React.FC = () => {
   const { tr } = useI18n();
+  const { initialState } = useModel('@@initialState');
   const params = useParams();
   const proxyId = Number(params.proxyId);
   const [form] = Form.useForm<API.CreateWebSSHSessionRequest>();
@@ -83,9 +88,17 @@ const WebSSHPage: React.FC = () => {
     label: item.username,
     value: item.username,
   }));
-  const watermarkText = target
-    ? `WebSSH · ${target.proxy_name} · ${target.application_name} · ${target.target_host}:${target.target_port}`
-    : 'WebSSH';
+  const watermarkTime = useSessionWatermarkTime();
+  const watermarkUser =
+    initialState?.currentUser?.email ||
+    initialState?.currentUser?.name ||
+    tr('未知用户', 'Unknown user');
+  const watermarkLines = target
+    ? [
+        buildSessionWatermarkLabel([watermarkUser, 'SSH', target.proxy_name]),
+        watermarkTime,
+      ]
+    : [buildSessionWatermarkLabel([watermarkUser, 'SSH']), watermarkTime];
 
   const flushTerminalInput = useCallback(() => {
     inputFlushQueuedRef.current = false;
@@ -747,13 +760,13 @@ const WebSSHPage: React.FC = () => {
           </div>
           <div
             className="webssh-terminal"
-            data-watermark={watermarkText}
             ref={terminalFrameRef}
             tabIndex={0}
             onClick={focusTerminal}
             onMouseDown={focusTerminal}
           >
             <div className="webssh-terminal-screen" ref={terminalHostRef} />
+            <SessionWatermark lines={watermarkLines} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace single large WebSSH/WebDesktop watermarks with a reusable tiled session watermark component.
- Show compact audit text using account, protocol, access name, and a separate timestamp line.
- Remove the WeChat footer link and QR tooltip.

## Validation
- npm run build